### PR TITLE
Add clean-tmux script and bin deployment

### DIFF
--- a/bin/clean-tmux
+++ b/bin/clean-tmux
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo "Cleaning tmux sessions..."
+
+# Kill all tmux sessions
+if tmux list-sessions >/dev/null 2>&1; then
+    tmux kill-server
+    echo "All tmux sessions killed."
+else
+    echo "No active tmux sessions."
+fi
+
+# Remove tmux-resurrect saved sessions
+RESURRECT_DIR="$HOME/.tmux/resurrect"
+if [ -d "$RESURRECT_DIR" ]; then
+    rm -rf "$RESURRECT_DIR"
+    echo "Removed saved sessions: $RESURRECT_DIR"
+else
+    echo "No saved sessions found."
+fi
+
+echo "Done. tmux is now clean."

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -23,10 +23,10 @@ set -g mouse on
 
 # Change keybinds for splitting windows
 unbind %
-bind | split-window -h
+bind | split-window -h -c "#{pane_current_path}"
 
 unbind '"'
-bind - split-window -v
+bind - split-window -v -c "#{pane_current_path}"
 
 # Add keybind for easily refreshing tmux configuration
 unbind r
@@ -54,6 +54,9 @@ bind -T copy-mode-vi WheelUpPane send-keys -X -N 1 scroll-up
 bind -T copy-mode-vi WheelDownPane send-keys -X -N 1 scroll-down
 
 # Auto-name session is handled by shell precmd hook (see zshrc)
+
+# Split window vertically on session creation
+set-hook -g session-created 'split-window -v -c "#{pane_current_path}"'
 
 # Set terminal title to session name
 set-option -g set-titles on

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -53,10 +53,12 @@ unbind -T copy-mode-vi MouseDragEnd1Pane # don't exit copy mode after dragging w
 bind -T copy-mode-vi WheelUpPane send-keys -X -N 1 scroll-up
 bind -T copy-mode-vi WheelDownPane send-keys -X -N 1 scroll-down
 
-# Auto-name session is handled by shell precmd hook (see zshrc)
+# Auto-name session/window is handled by shell precmd hook (see zshrc)
+set -g automatic-rename off
+set -g allow-rename off
 
 # Split window vertically on session creation
-set-hook -g session-created 'split-window -v -c "#{pane_current_path}"'
+set-hook -g session-created 'split-window -h -c "#{pane_current_path}"'
 
 # Set terminal title to session name
 set-option -g set-titles on

--- a/configs/tmux/tmux.conf
+++ b/configs/tmux/tmux.conf
@@ -53,8 +53,7 @@ unbind -T copy-mode-vi MouseDragEnd1Pane # don't exit copy mode after dragging w
 bind -T copy-mode-vi WheelUpPane send-keys -X -N 1 scroll-up
 bind -T copy-mode-vi WheelDownPane send-keys -X -N 1 scroll-down
 
-# Auto-name session with current directory
-set-hook -g session-created 'rename-session "#{b:pane_current_path}"'
+# Auto-name session is handled by shell precmd hook (see zshrc)
 
 # Set terminal title to session name
 set-option -g set-titles on

--- a/configs/zsh/zshrc
+++ b/configs/zsh/zshrc
@@ -51,5 +51,13 @@ source $shoichi_dir/alias.zsh
 # Android Studio JDK
 export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"
 
+# Auto-rename tmux session to current directory name
+_tmux_rename_session() {
+  if [ -n "$TMUX" ]; then
+    tmux rename-session "$(basename "$PWD")"
+  fi
+}
+precmd_functions+=(_tmux_rename_session)
+
 eval "$(direnv hook zsh)"
 export PATH="$HOME/.local/bin:$PATH"

--- a/configs/zsh/zshrc
+++ b/configs/zsh/zshrc
@@ -51,13 +51,14 @@ source $shoichi_dir/alias.zsh
 # Android Studio JDK
 export PATH="/opt/homebrew/opt/openjdk/bin:$PATH"
 
-# Auto-rename tmux session to current directory name
-_tmux_rename_session() {
+# Auto-rename tmux session and window to current directory name
+_tmux_rename() {
   if [ -n "$TMUX" ]; then
     tmux rename-session "$(basename "$PWD")"
+    tmux rename-window "$(basename "$PWD")"
   fi
 }
-precmd_functions+=(_tmux_rename_session)
+precmd_functions+=(_tmux_rename)
 
 eval "$(direnv hook zsh)"
 export PATH="$HOME/.local/bin:$PATH"

--- a/scripts/deploy-configs.sh
+++ b/scripts/deploy-configs.sh
@@ -184,6 +184,21 @@ deploy_ghostty () {
   mode_directory "$1" "${HOME}/.config/ghostty"
 }
 
+## Deploy bin scripts to ~/.local/bin
+deploy_bin() {
+    local bin_dir="$ROOT_DIR/bin"
+    local target_dir="$HOME/.local/bin"
+    mkdir -p "$target_dir"
+    find "$bin_dir" -type f | while read -r script; do
+        local name
+        name="$(basename "$script")"
+        mode_file "$script" "$target_dir/$name"
+    done
+}
+
+echo "${MODE} bin"
+deploy_bin
+
 find "$CONFIGS" -not -path '*/\.*' -mindepth 1 -maxdepth 1 -type d | while read -r DIR_FULLPATH; do
   DIR_NAME=${DIR_FULLPATH##*/}
   echo "${MODE} ${DIR_NAME}"


### PR DESCRIPTION
## Summary
- tmuxの全セッション終了とresurrect保存データ削除を行う `clean-tmux` ユーティリティスクリプトを追加
- `bin/` ディレクトリを新設し、`deploy-configs.sh` で `~/.local/bin/` へ自動シンボリックリンクする仕組みを追加
- tmuxセッション名が番号になる問題を修正（`session-created` フックからzsh `precmd` フックに移行）
- ペイン分割時にカレントディレクトリを引き継ぐように修正
- セッション作成時に自動で垂直2ペイン分割するように設定

## Test plan
- [ ] `./scripts/deploy-configs.sh link <root_dir>` を実行し、`~/.local/bin/clean-tmux` にシンボリックリンクが作成されることを確認
- [ ] `clean-tmux` コマンドでtmuxセッションが終了し、`~/.tmux/resurrect/` が削除されることを確認
- [ ] tmux起動時にセッション名がディレクトリ名になることを確認
- [ ] `prefix + |` / `prefix + -` でカレントディレクトリが引き継がれることを確認
- [ ] tmux起動時に自動で垂直2ペインになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)