### PR TITLE
Add markview.nvim plugin for markdown preview

### DIFF
--- a/configs/nvim/lua/shoichi/plugins/markview.lua
+++ b/configs/nvim/lua/shoichi/plugins/markview.lua
@@ -1,0 +1,19 @@
+return {
+  "OXY2DEV/markview.nvim",
+  ft = { "markdown" },
+  dependencies = {
+    "nvim-treesitter/nvim-treesitter",
+    "nvim-tree/nvim-web-devicons",
+  },
+  config = function()
+    require("markview").setup({
+      preview = {
+        modes = { "n", "no", "c" },
+        hybrid_modes = { "n" },
+      },
+    })
+
+    vim.keymap.set("n", "<leader>mp", "<cmd>Markview Toggle<CR>", { desc = "Toggle markview" })
+    vim.keymap.set("n", "<leader>ms", "<cmd>Markview splitToggle<CR>", { desc = "Toggle markview split" })
+  end,
+}


### PR DESCRIPTION
## Summary
- Neovim内でMarkdownファイルをリッチに描画する markview.nvim を追加
- 見出し・リスト・コードブロック・テーブル等を装飾表示
- ハイブリッドモードで編集中のカーソル行だけ生Markdownを表示

## Keymaps
- `<leader>mp` — プレビューのトグル
- `<leader>ms` — 分割プレビューのトグル

## Test plan
- [ ] Neovimを再起動してlazy.nvimが自動インストールすることを確認
- [ ] `.md` ファイルを開いてプレビューが描画されることを確認
- [ ] `<leader>mp` でトグルできることを確認
- [ ] `<leader>ms` で分割プレビューが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)