### PR TITLE
Fix dependency-order issues in bootstrap flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,8 @@ Linux_setup:
 	make linux_support_japanese
 	make install_apt_packages_from_brew
 	make font
-	make zsh
 	make link
+	make zsh
 	make zsh_extensions
 	make tmux
 	make change-default-shell
@@ -148,8 +148,8 @@ Darwin_setup:
 	@echo "\n=== macOS Setup ==="
 	make brew_install
 	make brew_setup
-	make zsh
 	make link
+	make zsh
 	make zsh_extensions
 	make tmux
 	make change-default-shell
@@ -223,7 +223,8 @@ fish:
 zsh:
 	@echo "Setup Zsh\n"
 	make check-sudo
-	sudo -n sh $(SETUP_ZSH)
+	# Preserve PATH so brew's zsh is discoverable inside the script
+	sudo -n -E env PATH="$$PATH" sh $(SETUP_ZSH)
 
 .PHONY: zsh_extensions
 zsh_extensions:

--- a/scripts/change-default-shell.sh
+++ b/scripts/change-default-shell.sh
@@ -5,8 +5,21 @@ select_shell_noninteractive() {
   # フルパス指定にも対応（/bin/zsh → zsh に正規化してから検索）
   local basename_target
   basename_target=$(basename "$target")
-  local found
-  found=$(grep -E "^[^#]" /etc/shells | grep -E "/${basename_target}$" | head -n1)
+
+  # /etc/shells から候補を全て列挙し、Homebrew パスを優先する。
+  # システムの /bin/zsh が古いケースがあるため、brew zsh を見つけたらそちらを使う。
+  local matches
+  matches=$(grep -E "^[^#]" /etc/shells | grep -E "/${basename_target}$" || true)
+
+  local found=""
+  # 優先順位: /opt/homebrew → /usr/local → /home/linuxbrew → その他
+  for prefix in /opt/homebrew/bin /usr/local/bin /home/linuxbrew/.linuxbrew/bin; do
+    found=$(echo "$matches" | grep -E "^${prefix}/${basename_target}$" | head -n1 || true)
+    [ -n "$found" ] && { echo "$found"; return 0; }
+  done
+
+  # 上記で見つからなければ /etc/shells の最初のエントリ
+  found=$(echo "$matches" | head -n1)
   if [ -z "$found" ]; then
     found=$(command -v "$basename_target" 2>/dev/null)
   fi

--- a/scripts/install-fonts.sh
+++ b/scripts/install-fonts.sh
@@ -1,7 +1,23 @@
 #!/bin/bash
 
-printf "Installing fonts...\\n"
-# Install Nerd Fonts
-"$SCRIPTS"/git-clone.sh https://github.com/ryanoasis/nerd-fonts.git
-"$CLONED_DIR_PATH"/nerd-fonts/install.sh
+set -e
+
+# $SCRIPTS は Makefile から export される。単体実行時のフォールバックを用意。
+SCRIPTS="${SCRIPTS:-$(cd "$(dirname "$0")" && pwd)}"
+ROOT_DIR="$(cd "$SCRIPTS/.." && pwd)"
+
+printf "Installing fonts...\n"
+
+# Nerd Fonts を clone（git-clone.sh は cwd の deps/ 配下にcloneする）
+cd "$ROOT_DIR"
+"$SCRIPTS/git-clone.sh" https://github.com/ryanoasis/nerd-fonts.git
+
+# git-clone.sh の export は子プロセスで死ぬため、ここで直接パスを組み立てる
+NERD_FONTS_DIR="$ROOT_DIR/deps/nerd-fonts"
+if [ ! -x "$NERD_FONTS_DIR/install.sh" ]; then
+    echo "nerd-fonts install.sh not found at $NERD_FONTS_DIR"
+    exit 1
+fi
+
+"$NERD_FONTS_DIR/install.sh"
 echo "Installed fonts!!"

--- a/scripts/setup-zsh.sh
+++ b/scripts/setup-zsh.sh
@@ -2,9 +2,23 @@
 
 ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 SCRIPTS="$ROOT_DIR/scripts"
-ZSH_PATH=$(which zsh)
 
-if command -v zsh >/dev/null 2>&1; then
+# Prefer Homebrew's zsh over the system /bin/zsh.
+# When invoked via sudo, PATH may be sanitized — check brew prefixes directly.
+find_zsh() {
+    for candidate in /opt/homebrew/bin/zsh /usr/local/bin/zsh /home/linuxbrew/.linuxbrew/bin/zsh; do
+        if [ -x "$candidate" ]; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    command -v zsh 2>/dev/null
+}
+
+ZSH_PATH=$(find_zsh)
+
+if [ -n "$ZSH_PATH" ] && [ -x "$ZSH_PATH" ]; then
+    echo "Using zsh at: $ZSH_PATH"
     # set to the default shell to zsh
     # sudo -n sed -i.bak '/\/bin\/zsh/d' /etc/shells # remove existing zsh path for mac
     if ! grep -q "^$ZSH_PATH$" /etc/shells; then


### PR DESCRIPTION
## Summary

Sub-agent による依存関係レビューで検出された Critical 2件 + Major 1件を修正。

## Critical

### C1: `make zsh` を `make link` より前に実行していた
- `Darwin_setup` / `Linux_setup` の順序で oh-my-zsh が先に `~/.zshrc` をインストールし、`~/.zshrc.pre-oh-my-zsh` にリネームしてしまう
- また `setup-zsh.sh:39` の `source ~/.zshrc` が link 前で未配置ファイルを参照
- **修正**: `link` を `zsh` の前に移動

### C3+C4: brew zsh が `/etc/shells` に登録されず、chsh が `/bin/zsh` を選んでしまう
- `Makefile:226` の `sudo -n sh $(SETUP_ZSH)` で sudo の sanitized PATH に切り替わる
- 結果 `which zsh` は `/bin/zsh`（macOS標準）を返し、brew zsh が `/etc/shells` に追加されない
- `change-default-shell.sh` も `/etc/shells` の最初のエントリ `/bin/zsh` を選んでしまう
- **「Homebrew zsh への切替が実は成功していなかった」**
- **修正**:
  1. `sudo -E env PATH=\"\$PATH\"` で PATH を継承
  2. `setup-zsh.sh` に `find_zsh()` を追加し brew prefix を直接探索
  3. `change-default-shell.sh` で brew パスを優先するロジック

## Major

### M2: `install-fonts.sh` の `\$CLONED_DIR_PATH` がサブシェル境界を越えない
- `git-clone.sh` が export しても子プロセスで終了し、呼び出し元には届かない
- → `make font` は実質壊れていた
- **修正**: `\$ROOT_DIR/deps/nerd-fonts` を直接構築、`set -e` とガード追加

## Test plan

- [x] `make test`: 全 38 テスト pass
- [x] `bash -n` 構文チェック: 全ファイル OK
- [x] **動作確認**: `DOTFILES_DEFAULT_SHELL=zsh` で `change-default-shell.sh` を走らせ、`/opt/homebrew/bin/zsh` が選ばれることを確認（修正前は `/bin/zsh` だった）

## Before / After

```
# Before
\$ DOTFILES_DEFAULT_SHELL=zsh ./scripts/change-default-shell.sh
Using DOTFILES_DEFAULT_SHELL: /bin/zsh   # ❌ システム zsh

# After
\$ DOTFILES_DEFAULT_SHELL=zsh ./scripts/change-default-shell.sh
Using DOTFILES_DEFAULT_SHELL: /opt/homebrew/bin/zsh   # ✅ brew zsh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)