### PR TITLE
Add iOS/cloud/dev tools to Brewfile

### DIFF
--- a/Brewfiles/macApps-Brewfile
+++ b/Brewfiles/macApps-Brewfile
@@ -14,7 +14,7 @@ brew "harelba/q/q"  # CSV処理ツール
 # フォント
 # ======================
 cask "font-hack-nerd-font"  # プログラミング用フォント
-brew "font-meslo-lg-nerd-font"  # ターミナル用フォント
+cask "font-meslo-lg-nerd-font"  # ターミナル用フォント
 
 # ======================
 # 開発ツール
@@ -27,7 +27,6 @@ cask "charles"  # HTTPプロキシ
 cask "docker"  # コンテナ管理
 cask "tower"  # Gitクライアント
 cask "transmit" # FTPクライアント
-cask "charles"  # HTTPプロキシ
 cask "rapidapi"  # API開発ツール
 
 # ======================
@@ -44,7 +43,6 @@ cask "claude"  # AIチャット
 cask "alfred"  # ランチャー
 cask "obsidian"  # ノートアプリ
 cask "figma"  # デザインツール
-cask "transmit"  # FTPクライアント
 
 # ======================
 # ブラウザ/ターミナル

--- a/Brewfiles/minimum-Brewfile
+++ b/Brewfiles/minimum-Brewfile
@@ -43,7 +43,32 @@ brew "pyenv"  # Pythonバージョン管理
 brew "rbenv"  # Rubyバージョン管理
 brew "ruby-build"  # Rubyビルドツール
 brew "tfenv"  # Terraformバージョン管理
-brew "pyenv"
+brew "deno"  # TypeScript/JavaScriptランタイム
+brew "pnpm"  # 高速なNode.jsパッケージマネージャ
+
+# iOS / Swift 開発
+brew "swiftlint"  # Swiftコードのlinter
+brew "swiftformat"  # Swiftコードの自動フォーマッタ
+brew "xcbeautify"  # xcodebuild出力の整形ツール
+brew "fastlane"  # iOS/Androidアプリ配信自動化
+brew "mint"  # Swift製CLIツールのパッケージマネージャ
+brew "xcode-build-server"  # Swift LSPバックエンド（nvim等で使用）
+brew "periphery"  # Swift未使用コード検出
+
+# クラウド
+brew "firebase-cli"  # Firebase CLI
+cask "google-cloud-sdk"  # GCP CLI (gcloud, gsutil, bq)
+
+# 開発支援
+brew "shellcheck"  # シェルスクリプトlinter
+brew "shfmt"  # シェルスクリプトフォーマッタ
+brew "gitleaks"  # 秘密情報スキャン
+brew "difftastic"  # 構文解析ベースdiff
+brew "tokei"  # コード行数集計
+brew "act"  # GitHub Actionsのローカル実行
+brew "grpcurl"  # gRPCクライアント
+brew "mkcert"  # ローカルHTTPS開発用証明書発行
+brew "graphviz"  # グラフ可視化（terraform graph等で使用）
 
 # ビルドツール
 brew "cmake"  # クロスプラットフォームビルドツール


### PR DESCRIPTION
## Summary

iOS開発・クラウド・Web/共通開発支援ツールを Brewfile に追加。ついでに既存の重複・誤定義バグも修正。

### iOS / Swift 開発
- swiftlint, swiftformat, xcbeautify, fastlane
- mint, xcode-build-server, periphery

### クラウド
- firebase-cli
- google-cloud-sdk (cask)

### 言語
- deno, pnpm

### 開発支援
- shellcheck, shfmt, gitleaks, difftastic, tokei
- act, grpcurl, mkcert, graphviz

### 同時に修正したバグ
- minimum-Brewfile: pyenv の重複削除
- macApps-Brewfile: charles, transmit の重複削除
- macApps-Brewfile: `brew \"font-meslo-lg-nerd-font\"` → `cask`（フォントはcask）

### 元リクエストから除外したもの（理由）
- aws-vault, session-manager-plugin, gh-aws-ssm, sourcekit-lsp, volta, httpie, terraform は素のbrewでは見つからず（tap や cask が必要）
- awscli は既に extra-Brewfile にあり
- tfenv (minimum 既存) が terraform バージョン管理を提供
- gh-copilot は gh extension のため別途 `gh extension install github/gh-copilot`

🤖 Generated with [Claude Code](https://claude.com/claude-code)