### PR TITLE
Fix bootstrap failures on clean macOS install

### DIFF
--- a/Brewfiles/extra-Brewfile
+++ b/Brewfiles/extra-Brewfile
@@ -1,5 +1,5 @@
 # Homebrewリポジトリの追加
-tap "homebrew/bundle"  # Homebrew Bundle用公式リポジトリ
+# Note: homebrew/bundle は brew 本体に統合されたため tap 不要 (2024年以降)
 tap "jesseduffield/lazygit"  # lazygitの非公式リポジトリ
 
 # 基本コマンドラインツール

--- a/Brewfiles/macApps-Brewfile
+++ b/Brewfiles/macApps-Brewfile
@@ -1,6 +1,7 @@
 # ======================
 # リポジトリ追加
 # ======================
+# Note: homebrew/bundle は brew 本体に統合されたため tap 不要 (2024年以降)
 tap "robotsandpencils/made"  # xcodes用リポジトリ
 tap "harelba/q"  # qコマンド用リポジトリ
 

--- a/Brewfiles/minimum-Brewfile
+++ b/Brewfiles/minimum-Brewfile
@@ -1,5 +1,5 @@
 # Homebrewリポジトリの追加
-tap "homebrew/bundle"  # Homebrew Bundle用公式リポジトリ
+# Note: homebrew/bundle は brew 本体に統合されたため tap 不要 (2024年以降)
 tap "jesseduffield/lazygit"  # lazygitの非公式リポジトリ
 
 # ファイル/テキスト操作
@@ -47,7 +47,9 @@ brew "deno"  # TypeScript/JavaScriptランタイム
 brew "pnpm"  # 高速なNode.jsパッケージマネージャ
 
 # iOS / Swift 開発
-brew "swiftlint"  # Swiftコードのlinter
+# Note: swiftlint は完全な Xcode.app が必要なため、bootstrap 後に
+# Xcode をApp Storeで入れてから `brew install swiftlint` するか、
+# `mint install realm/SwiftLint` で導入。
 brew "swiftformat"  # Swiftコードの自動フォーマッタ
 brew "xcbeautify"  # xcodebuild出力の整形ツール
 brew "fastlane"  # iOS/Androidアプリ配信自動化

--- a/Makefile
+++ b/Makefile
@@ -75,18 +75,24 @@ help:
 .PHONY: check-sudo
 check-sudo:
 	@echo "Check sudo"
+	@# sudo cache が生きているかを実コマンドで確認 (kill -0 だけでは不十分)
 	@if sudo -n true 2>/dev/null; then \
-		echo "Sudo is not required. Skipping."; \
-	elif [ -f $(SUDO_KEEPALIVE_PID) ] && kill -0 $$(cat $(SUDO_KEEPALIVE_PID)) 2>/dev/null; then \
-		echo "Sudo keep-alive already running."; \
+		echo "Sudo cache is valid."; \
+		if [ ! -f $(SUDO_KEEPALIVE_PID) ] || ! kill -0 $$(cat $(SUDO_KEEPALIVE_PID) 2>/dev/null) 2>/dev/null; then \
+			( while true; do sudo -n true; sleep 50; done ) >/dev/null 2>&1 & \
+			echo $$! > $(SUDO_KEEPALIVE_PID); \
+		fi; \
 	elif [ ! -t 0 ]; then \
 		echo "Error: sudo password required but stdin is not a TTY."; \
 		echo "Run 'sudo -v' manually before invoking this target,"; \
 		echo "or use NOPASSWD sudoers entry for this user."; \
 		exit 1; \
 	else \
-		echo "Requesting sudo password (cached for the rest of bootstrap)..."; \
+		echo "Requesting sudo password..."; \
 		sudo -v; \
+		if [ -f $(SUDO_KEEPALIVE_PID) ] && kill -0 $$(cat $(SUDO_KEEPALIVE_PID) 2>/dev/null) 2>/dev/null; then \
+			kill $$(cat $(SUDO_KEEPALIVE_PID)) 2>/dev/null; \
+		fi; \
 		( while true; do sudo -n true; sleep 50; done ) >/dev/null 2>&1 & \
 		echo $$! > $(SUDO_KEEPALIVE_PID); \
 	fi


### PR DESCRIPTION
## Summary

実機の clean macOS bootstrap で発生したエラーを修正。

## エラー内容

```
Tapping homebrew/bundle
Error: homebrew/bundle was deprecated. This tap is now empty...
Tapping homebrew/bundle has failed!

Installing swiftlint
swiftlint: A full installation of Xcode.app 8.0 is required...
Installing swiftlint has failed!

# ... 後続のbrew bundleは続いたが ...

make zsh
sudo: a password is required
make[2]: *** [zsh] Error 1
make[1]: *** [Darwin_setup] Error 2
make: *** [bootstrap] Error 2
```

## 修正内容

### 1. `tap \"homebrew/bundle\"` を全Brewfileから削除
homebrew/bundle は 2024年に brew 本体に統合され、tap が deprecated に。tap しようとすると即エラーになり brew bundle が中断する。

### 2. swiftlint を minimum-Brewfile から除外
swiftlint は完全な Xcode.app が必要（CLT だけでは不可）。bootstrap 時点では Xcode 未インストールのため必ず失敗する。
README/コメントで「Xcode インストール後に `brew install swiftlint` か `mint install realm/SwiftLint`」と案内。

### 3. check-sudo の false positive を修正
Makefile の check-sudo が「keep-alive PID が生きている」だけで sudo cache の生存を判定していた。

```
elif [ -f \$(SUDO_KEEPALIVE_PID) ] && kill -0 \$\$(cat \$(SUDO_KEEPALIVE_PID)) ...
    echo \"Sudo keep-alive already running.\"   # ← cache 切れててもここを通過
```

keep-alive プロセス自体は動いていても、長時間アイドル後や OS の sudo policy で cache が切れることがある。実機でこのケースに該当し、後段の `sudo -n -E env PATH=... sh setup-zsh.sh` が \"sudo: a password is required\" で失敗。

**修正**: 必ず `sudo -n true` で実際の cache を検査。切れていれば再プロンプト。

## Test plan

- [x] `make test`: 全 47 テスト pass
- [x] `bash -n` 構文チェック OK
- [x] `make -n check-sudo` で生成シェルスクリプトを確認

## 補足

実行ログで `DO YOU WANT TO SET COMPANY USER INFO?` が出ていたのは、ワンライナーに `NONINTERACTIVE=1` 等を付け忘れて対話モードで起動したため。本PRで修正後、READMEに記載のワンライナー（NONINTERACTIVE=1 + DOTFILES_*）を使えば全自動になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)