### PR TITLE
Pass --keep-zshrc to oh-my-zsh installer

### DIFF
--- a/scripts/setup-zsh.sh
+++ b/scripts/setup-zsh.sh
@@ -33,8 +33,10 @@ if [ -n "$ZSH_PATH" ] && [ -x "$ZSH_PATH" ]; then
     else
         echo "Oh My Zsh is not installed. Installing now..."
 
-        # Install oh-my-zsh without changing the shell immediately
-        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+        # --unattended: 対話なしでインストール、デフォルトシェル変更もしない
+        # --keep-zshrc: dotfiles 側で配置済みの ~/.zshrc を ~/.zshrc.pre-oh-my-zsh に
+        #               リネームせず、そのまま保持する
+        sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended --keep-zshrc
 
         echo "Oh My Zsh installation completed."
     fi


### PR DESCRIPTION
## Summary

oh-my-zsh installer がdotfilesのzshrcを上書きする問題を修正。

## 問題

`make bootstrap` の流れ:
1. `make link` で `~/.zshrc` → `dotfiles-public/configs/zsh/zshrc` のsymlink作成 ✅
2. `make zsh` 内で oh-my-zsh installer が実行
3. **oh-my-zsh が既存の `~/.zshrc` を `~/.zshrc.pre-oh-my-zsh` にリネームし、自前のテンプレートを設置** ❌
4. 結果: dotfiles の zshrc が効かなくなる

## 修正

oh-my-zsh installer に `--keep-zshrc` フラグを追加。既存の `~/.zshrc` を保持する。

```sh
sh -c "$(curl ... install.sh)" "" --unattended --keep-zshrc
```

## 既存環境の復旧手順

既に bootstrap 実行済みのユーザーは下記で復旧:

```bash
# .zshrc.pre-oh-my-zsh があれば復元
[ -f ~/.zshrc.pre-oh-my-zsh ] && mv ~/.zshrc.pre-oh-my-zsh ~/.zshrc

# 念のため symlink を作り直す
cd ~/workspace/dotfiles-public && make link

# 新シェルを起動 or source
exec zsh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)