### PR TITLE
Fix permission errors and related real-run issues

### DIFF
--- a/Brewfiles/minimum-Brewfile
+++ b/Brewfiles/minimum-Brewfile
@@ -59,7 +59,7 @@ brew "periphery"  # Swift未使用コード検出
 
 # クラウド
 brew "firebase-cli"  # Firebase CLI
-cask "google-cloud-sdk"  # GCP CLI (gcloud, gsutil, bq)
+cask "gcloud-cli"  # GCP CLI (gcloud, gsutil, bq) ※旧名 google-cloud-sdk
 
 # 開発支援
 brew "shellcheck"  # シェルスクリプトlinter

--- a/Makefile
+++ b/Makefile
@@ -235,8 +235,11 @@ fish:
 zsh:
 	@echo "Setup Zsh\n"
 	make check-sudo
-	# Preserve PATH so brew's zsh is discoverable inside the script
-	sudo -n -E env PATH="$$PATH" sh $(SETUP_ZSH)
+	# Run as the current user; setup-zsh.sh internally uses `sudo tee`
+	# only for /etc/shells. Running the whole script as root would make
+	# git-clone.sh create deps/* as root, causing later runs to hit
+	# Permission denied when removing them.
+	sh $(SETUP_ZSH)
 
 .PHONY: zsh_extensions
 zsh_extensions:

--- a/scripts/deploy-configs.sh
+++ b/scripts/deploy-configs.sh
@@ -213,7 +213,18 @@ deploy_fish () {
 deploy_vscode () {
   if [ "$OS" = "Darwin" ]; then
       local vscode_dir="${HOME}/Library/Application Support/Code/User"
+      # VS Code を起動したことがない場合ディレクトリが存在しないので作成
+      mkdir -p "$vscode_dir"
       mode_file "$1/settings.json" "$vscode_dir/settings.json"
+  fi
+}
+
+deploy_iterm2 () {
+  if [ "$OS" = "Darwin" ]; then
+      # iTerm2 の plist は ~/Library/Preferences/ に置く
+      local prefs_dir="${HOME}/Library/Preferences"
+      mkdir -p "$prefs_dir"
+      mode_file "$1/com.googlecode.iterm2.plist" "$prefs_dir/com.googlecode.iterm2.plist"
   fi
 }
 
@@ -265,6 +276,7 @@ find "$CONFIGS" -not -path '*/\.*' -mindepth 1 -maxdepth 1 -type d | while read 
     "zsh" ) deploy_zsh "$DIR_FULLPATH";;
     "fish" ) deploy_fish "$DIR_FULLPATH";;
     "vscode" ) deploy_vscode "$DIR_FULLPATH";;
+    "iterm2" ) deploy_iterm2 "$DIR_FULLPATH";;
     "nvim" ) deploy_nvim "$DIR_FULLPATH";;
     "karabiner" ) deploy_karabiner "$DIR_FULLPATH";;
     "wezterm" ) deploy_wezterm "$DIR_FULLPATH";;

--- a/scripts/git-clone.sh
+++ b/scripts/git-clone.sh
@@ -17,8 +17,18 @@ LINK_DIR=$2
 mkdir -p deps
 chmod 775 deps
 
-# リポジトリクローン
-rm -rf "deps/$REPO_NAME"
+# 既存ディレクトリを削除（過去に sudo 経由で実行され root 所有になっている
+# 可能性があるため、通常削除に失敗したら sudo にフォールバック）
+if [ -e "deps/$REPO_NAME" ] || [ -L "deps/$REPO_NAME" ]; then
+  if ! rm -rf "deps/$REPO_NAME" 2>/dev/null; then
+    echo "Removing root-owned deps/$REPO_NAME with sudo..."
+    sudo -n rm -rf "deps/$REPO_NAME" || {
+      echo "Failed to remove deps/$REPO_NAME (sudo not available)"
+      exit 1
+    }
+  fi
+fi
+
 echo "Cloning $REPO_URL into deps/$REPO_NAME..."
 if ! git clone "$REPO_URL" "deps/$REPO_NAME" --depth 1; then
   echo "Failed to clone repository"

--- a/scripts/install-zsh-extensions.sh
+++ b/scripts/install-zsh-extensions.sh
@@ -3,23 +3,22 @@
 ROOT_DIR=$(cd "$(dirname "$0")/.." && pwd)
 SCRIPTS="$ROOT_DIR/scripts"
 
-zsh -c 'source ~/.zshrc'
-
-mkdir "$HOME"/.zsh
-chmod 775 "$HOME"/.zsh
+mkdir -p "$HOME/.zsh"
+chmod 775 "$HOME/.zsh"
 
 # fzf-git
 "$SCRIPTS"/git-clone.sh https://github.com/junegunn/fzf-git.sh.git "$HOME"/.config/zsh/fzf-git
 
-# bat
-mkdir -p "$(bat --config-dir)/themes"
-curl -o "$(bat --config-dir)/themes/tokyonight_night.tmTheme" https://raw.githubusercontent.com/folke/tokyonight.nvim/main/extras/sublime/tokyonight_night.tmTheme
-bat cache --build
+# bat (tokyonight theme)
+if command -v bat >/dev/null 2>&1; then
+    mkdir -p "$(bat --config-dir)/themes"
+    curl -fsSL -o "$(bat --config-dir)/themes/tokyonight_night.tmTheme" \
+        https://raw.githubusercontent.com/folke/tokyonight.nvim/main/extras/sublime/tokyonight_night.tmTheme
+    bat cache --build
+fi
 
 # zsh-autosuggestions
 "$SCRIPTS"/git-clone.sh https://github.com/zsh-users/zsh-autosuggestions "$HOME"/.zsh/zsh-autosuggestions
 
 # zsh-syntax-highlighting
 "$SCRIPTS"/git-clone.sh https://github.com/zsh-users/zsh-syntax-highlighting.git "$HOME"/.zsh/zsh-syntax-highlighting
-
-zsh -c 'source ~/.zshrc'


### PR DESCRIPTION
## Summary

実機 bootstrap で発生した `rm: Permission denied` 連鎖と関連エラーを修正。

## 主要バグ: `rm: deps/zsh-*: Permission denied`

原因:
1. 旧 Makefile の `make zsh` が `sudo -n -E env PATH=... sh setup-zsh.sh` で setup-zsh.sh を **root として実行**
2. その中で git-clone.sh が `deps/zsh-autosuggestions` 等を **root 所有**で作成
3. 次回 `make zsh_extensions`（sudo なし）で git-clone.sh の `rm -rf deps/X` が Permission denied

修正:
- **Makefile**: `make zsh` の sudo wrapper を削除。setup-zsh.sh 内部で必要な箇所だけ `sudo -n tee /etc/shells` 使用
- **git-clone.sh**: `rm -rf` が失敗したら `sudo -n rm -rf` にフォールバックして既存の root 所有 deps を救う

## 同時に修正したもの

- **Brewfile**: `google-cloud-sdk` → `gcloud-cli`（upstream リネーム対応）
- **install-zsh-extensions.sh**:
  - `mkdir $HOME/.zsh` → `mkdir -p`（2回目実行のwarning解消）
  - 冒頭の `zsh -c 'source ~/.zshrc'` を削除（plugin未配置時のエラー回避）
  - `bat` を `command -v` でガード
- **deploy-configs.sh**:
  - `deploy_vscode`: `Application Support/Code/User` を事前 mkdir（VS Code 未起動時の `ln: No such file` 解消）
  - **`deploy_iterm2` 新規追加** + case branch（"No deployment function for iterm2" 解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)