### PR TITLE
Add ghostty, Chrome, 1Password to extra-Brewfile

### DIFF
--- a/Brewfiles/extra-Brewfile
+++ b/Brewfiles/extra-Brewfile
@@ -12,3 +12,11 @@ brew "coreutils"  # GNUコアユーティリティ(cpなど)
 
 # マルチメディア/ユーティリティ
 brew "ffmpeg"  # 動画/音声処理
+
+# パスワード管理
+brew "1password-cli"  # 1Password CLI (op コマンド)
+
+# アプリケーション
+cask "ghostty"  # モダンなGPU加速ターミナル
+cask "google-chrome"  # Webブラウザ
+cask "1password"  # パスワードマネージャ


### PR DESCRIPTION
## Summary

extra-Brewfile に以下を追加:

- `cask "ghostty"` — モダンなGPU加速ターミナル
- `cask "google-chrome"` — Webブラウザ
- `cask "1password"` — パスワードマネージャ
- `brew "1password-cli"` — op コマンド（gh auth / aws-vault との連携用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)