### PR TITLE
Fix Ghostty: set Nerd Font so prompt icons render

### DIFF
--- a/configs/ghostty/config
+++ b/configs/ghostty/config
@@ -2,6 +2,14 @@
 # Migrated from Wezterm config
 
 # ============================================
+# Font
+# ============================================
+# Nerd Font が必要（starship, p10k, powerlevel10k のアイコンを表示するため）
+# Brewfile の `font-hack-nerd-font` でインストール済みのものを使用
+font-family = "Hack Nerd Font Mono"
+font-size = 13
+
+# ============================================
 # Color Scheme (coolnight)
 # ============================================
 


### PR DESCRIPTION
## 原因

shellのアイコン (starship / p10k) が `?` で表示される原因:
- `configs/ghostty/config` に **`font-family` 設定がなかった**
- Ghostty がデフォルトフォントにフォールバック → グリフ未収録のため `?`

フォント自体（Hack Nerd Font / MesloLGS Nerd Font）は Brewfile 経由で `~/Library/Fonts/` にインストール済みだった。

## 修正

```
font-family = "Hack Nerd Font Mono"
font-size = 13
```

を ghostty config に追加。

## 適用手順

このPRをマージ後:
```bash
cd ~/workspace/dotfiles-public && git pull
# config は symlink なのですぐ反映される
# ghostty を再起動するか Cmd+, → Reload Configuration
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)