### PR TITLE
ssh-key-gen: rewrite HTTPS origin to SSH on existing-key path too

### DIFF
--- a/scripts/ssh-key-gen.sh
+++ b/scripts/ssh-key-gen.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+SSH_REMOTE="git@github.com:syouit523/dotfiles-public.git"
+HTTPS_REMOTE_PATTERN="https://github.com/"
+
 connection_test_github () {
     echo "DO YOU WANT TO CONNECTION TEST TO GITHUB? (Y/n)"
     read -r flag
@@ -8,22 +11,39 @@ connection_test_github () {
     fi
 }
 
+# 現在のリポジトリの origin が HTTPS だったら SSH に切り替える
+switch_remote_to_ssh () {
+    if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+        return 0
+    fi
+    local current_url
+    current_url=$(git remote get-url origin 2>/dev/null || echo "")
+    case "$current_url" in
+        "$HTTPS_REMOTE_PATTERN"*)
+            echo "Switching origin from HTTPS to SSH..."
+            git remote set-url origin "$SSH_REMOTE"
+            echo "  Before: $current_url"
+            echo "  After:  $SSH_REMOTE"
+            ;;
+    esac
+}
+
 # SSHキーが既に存在するか確認
 KEY_PATH_ED25519="$HOME/.ssh/id_ed25519"
 if [ -f "$KEY_PATH_ED25519" ]; then
     echo "SSHキーは既に存在します。"
+    switch_remote_to_ssh
     connection_test_github || exit 0
 else
     echo "SSHキーが見つかりません。新しいキーを作成します。"
-    
+
     # GitHub CLIで認証およびSSHキーの自動作成・追加
     echo "GitHubアカウントにログインし、SSHキーを登録します。"
     gh auth login -p ssh
 
     # 接続テスト
     connection_test_github
-    
-    # リモートURLをSSH接続に変更
-    git remote set-url origin git@github.com:syouit523/dotfiles-public.git || exit 0
-fi
 
+    # リモートURLをSSH接続に変更
+    switch_remote_to_ssh
+fi


### PR DESCRIPTION
## 問題

`scripts/init.sh` は HTTPS でclone:
```
REPO_URL="https://github.com/syouit523/dotfiles-public.git"
```

そのため bootstrap 後の `git pull` で認証が必要に。SSH鍵があっても origin が HTTPS のままで詰む。

## 修正

`scripts/ssh-key-gen.sh` で:
- **SSH鍵が既存**の場合も `git remote set-url` を実行
- origin URL が HTTPS パターンの場合のみ書き換え（既に SSH/別remote ならスキップ）

## 手動復旧

このPRをマージ後、既存ユーザーは:
```bash
cd ~/workspace/dotfiles-public
git remote set-url origin git@github.com:syouit523/dotfiles-public.git
git pull
```
または:
```bash
make ssh-key-gen
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)