### PR TITLE
Fix karabiner silently skipped in interactive mode

### DIFF
--- a/scripts/deploy-configs.sh
+++ b/scripts/deploy-configs.sh
@@ -117,20 +117,26 @@ mode_directory() {
     echo "  Target: $target_dir"
     
     # すべてのファイルを再帰的に処理
-    find "$source_dir" -type f | while read -r source_path; do
+    # find ... | while だと将来 mode_file 内で read を使った時に
+    # 同じ stdin パイプ食いが起きるため、配列で受けて while-read-here-string にする。
+    local source_files
+    source_files=$(find "$source_dir" -type f 2>/dev/null)
+    [ -z "$source_files" ] && return 0
+    while IFS= read -r source_path; do
+        [ -z "$source_path" ] && continue
         # 相対パスを計算
         local rel_path="${source_path#"$source_dir"/}"
         local target_path="$target_dir/$rel_path"
-        
+
         # ターゲットディレクトリを作成
         mkdir -p "$(dirname "$target_path")"
-        
+
         echo "Linking:"
         echo "  From: $source_path"
         echo "  To: $target_path"
-        
+
         mode_file "$source_path" "$target_path"
-    done
+    done <<< "$source_files"
 }
 
 deploy_git () {
@@ -145,21 +151,29 @@ deploy_git () {
         cp "$1/gitconfig" ~/.gitconfig
         git config --global core.excludesfile ~/.gitignore_global
         ## SET USER CONFIG INTO COMPANY DIR
+        # 注意: ここの read は **必ず /dev/tty から読む**。
+        # deploy-configs.sh は呼び出し側で `find ... | while read` または
+        # `<<< "$..."` 経由のループ内で source / 実行されることがあり、
+        # そのままだと read が次のループエントリを消費して
+        # configs/karabiner などが飛ばされる事故が起きる。
         if [ "$NONINTERACTIVE" = "1" ]; then
             flag="n"
             echo "NONINTERACTIVE: skipping company user info setup"
-        else
+        elif [ -e /dev/tty ]; then
             echo "DO YOU WANT TO SET COMPANY USER INFO?: y/n"
-            read -r flag
+            read -r flag </dev/tty
+        else
+            flag="n"
+            echo "No TTY: skipping company user info setup"
         fi
         if [ "$flag" = "y" ] || [ "$flag" = "Y" ]; then
             echo "INPUT THE COMPANY NAME: "
-            read -r company
+            read -r company </dev/tty
             echo "CREATED THE COMPANY DIRECTORY INTO THE WORKSPACE"
             echo "INPUT YOUR COMPANY E-MAIL: "
-            read -r mail_company
+            read -r mail_company </dev/tty
             echo "INPUT YOUR NAME: "
-            read -r name_company
+            read -r name_company </dev/tty
 
             COMPANY_CONFIG="${WORKSPACE}/${company}/.${company}.gitconfig"
             mkdir -p "$WORKSPACE/${company}"
@@ -256,18 +270,32 @@ deploy_ghostty () {
 deploy_bin() {
     local bin_dir="$ROOT_DIR/bin"
     local target_dir="$HOME/.local/bin"
+    if [ ! -d "$bin_dir" ]; then
+        return 0
+    fi
     mkdir -p "$target_dir"
-    find "$bin_dir" -type f | while read -r script; do
+    local scripts
+    scripts=$(find "$bin_dir" -type f 2>/dev/null)
+    [ -z "$scripts" ] && return 0
+    while IFS= read -r script; do
+        [ -z "$script" ] && continue
         local name
         name="$(basename "$script")"
         mode_file "$script" "$target_dir/$name"
-    done
+    done <<< "$scripts"
 }
 
 echo "${MODE} bin"
 deploy_bin
 
-find "$CONFIGS" -not -path '*/\.*' -mindepth 1 -maxdepth 1 -type d | while read -r DIR_FULLPATH; do
+# find の結果を一旦変数に取り込んでからループする。
+# `find ... | while read` 形式だと deploy_git 内の `read -r flag` などが
+# パイプ stdin から find の次の行を消費してしまい、特定のディレクトリが
+# 飛ばされる事故が起きる（過去に karabiner が deploy_git の prompt に
+# 食われてスキップされた）。
+CONFIG_DIRS=$(find "$CONFIGS" -not -path '*/\.*' -mindepth 1 -maxdepth 1 -type d)
+while IFS= read -r DIR_FULLPATH; do
+  [ -z "$DIR_FULLPATH" ] && continue
   DIR_NAME=${DIR_FULLPATH##*/}
   echo "${MODE} ${DIR_NAME}"
   case "$DIR_NAME" in
@@ -285,4 +313,4 @@ find "$CONFIGS" -not -path '*/\.*' -mindepth 1 -maxdepth 1 -type d | while read 
     "ghostty" ) deploy_ghostty "$DIR_FULLPATH";;
     * ) echo "No deployment function for ${DIR_NAME}";;
   esac
-done
+done <<< "$CONFIG_DIRS"

--- a/tests/test_deploy_configs.bats
+++ b/tests/test_deploy_configs.bats
@@ -238,5 +238,5 @@ teardown() {
   run bash -c "NONINTERACTIVE=1 \"$SOURCE_SCRIPT\" link \"$TEST_ROOT\" </dev/null"
 
   [ "$status" -eq 0 ]
-  [[ "$output" == *"NONINTERACTIVE: skipping company user info setup"* ]]
+  [[ "$output" == *"skipping company user info setup"* ]]
 }


### PR DESCRIPTION
## 原因

\`scripts/deploy-configs.sh\` の `find ... | while read DIR_FULLPATH` パターンと、`deploy_git` 内の対話 prompt `read -r flag` が **同じ stdin パイプを共有** していた。

```
find configs ... → vim, nvim, ..., git, karabiner, ghostty
while read DIR_FULLPATH         # ← パイプから git を読む
  case git → deploy_git
    read -r flag                # ← 同じパイプから karabiner を読む（ここで消費）
  end
while read DIR_FULLPATH         # ← 次は ghostty を読む（karabiner はスキップ）
```

結果: 新規 mac で対話モード（NONINTERACTIVE 未設定）で実行すると、karabiner が silent にスキップされ、Karabiner-Elements が初回起動時に作った空の設定がそのまま残る。

## 修正

1. **top-level の config-dirs ループ**を `<<< "$CONFIG_DIRS"` (here-string) ベースに変更。stdin パイプ食いを構造的に防ぐ。
2. **deploy_git の prompt を `</dev/tty` から読む**。これが本質的な修正。here-string ベースでも `read` が同じ stdin を食う可能性があるため、ユーザー入力チャネルを明示的に分離。
3. `mode_directory` / `deploy_bin` も同じパターン + 空 find 出力ガード追加。
4. テストの NONINTERACTIVE prompt-skip assertion 緩和。

## Test plan

- [x] \`make test\`: 全 52 テスト pass
- [x] /tmp/deploy-test/ で `echo "n" | bash deploy-configs.sh link ...` を再現実行し、karabiner が link されることを確認
- [x] NONINTERACTIVE=1 でも同様に karabiner が link されることを確認

## あなたの環境での復旧

```bash
cd ~/workspace/dotfiles-public && git pull

# karabiner.json を dotfiles の symlink に置き換える
# (Karabiner-Elements を一旦終了してから実行)
make link
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)