### PR TITLE
Guard BAT_THEME behind theme file existence

### DIFF
--- a/configs/zsh/shoichi/command-extensions.zsh
+++ b/configs/zsh/shoichi/command-extensions.zsh
@@ -28,7 +28,13 @@ if [ -f "$HOME/.config/zsh/fzf-git/fzf-git.sh" ]; then
 fi
 
 # ----- Bat (better cat) -----
-export BAT_THEME=tokyonight_night
+# テーマ未インストールの環境で bat を実行するたびに
+# "[bat warning]: Unknown theme 'tokyonight_night'" が出るのを防ぐため、
+# テーマファイルの存在を確認してから設定する
+# （テーマのインストールは install-zsh-extensions.sh が行う）
+if [ -f "${XDG_CONFIG_HOME:-$HOME/.config}/bat/themes/tokyonight_night.tmTheme" ]; then
+  export BAT_THEME=tokyonight_night
+fi
 
 # eza & bat
 export FZF_CTRL_T_OPTS="--preview 'bat -n --color=always --line-range :500 {}'"


### PR DESCRIPTION
## 概要

テーマ未インストールの環境で bat を実行するたびに以下の警告が出る問題の修正です。

```
[bat warning]: Unknown theme 'tokyonight_night', using default.
```

## 原因

`BAT_THEME=tokyonight_night` は `command-extensions.zsh` で無条件に export される一方、テーマ本体のインストールは `install-zsh-extensions.sh`(`make zsh_extensions`)に依存しており、未実行のマシンでは bat が未知のテーマ名を受け取っていました。

## 修正

テーマファイル(`~/.config/bat/themes/tokyonight_night.tmTheme`)の存在を確認してから `BAT_THEME` を設定するように変更。未インストール環境では bat のデフォルトテーマが警告なしで使われます。

## 検証

- 実際の zsh セッションで `BAT_THEME` が設定され、bat 実行時に警告が出ないことを確認
- `zsh -n` 構文チェック OK
- テーマ未インストール状態の再現(ファイル不在時は BAT_THEME 未設定 → 警告なし)

なお、このマシンにはテーマを手動インストール済みです(`make zsh_extensions` 相当の bat セクションを実行)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)