### PR TITLE
Add docs/ with per-tool usage documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dotfiles-public
 
+> 📚 各ツールの操作方法・キーバインド・プラグインの使い方は **[docs/](docs/README.md)** を参照してください(tmux / zsh / fish / Neovim / git / ターミナル)。
+
 ## ⚠️ Breaking Changes
 
 - **`make bootstrap` から `make ssh-key-gen` を除外**しました。SSH キー生成と `gh auth login` は対話が必須なため、bootstrap 後に手動で `make ssh-key-gen` を実行してください。
@@ -127,6 +129,7 @@ bash <(curl -sL https://raw.githubusercontent.com/syouit523/dotfiles-public/main
 
 | パス | 内容 |
 |------|------|
+| `docs/` | 各ツールの操作方法・キーバインドのドキュメント |
 | `Makefile` | すべてのセットアップの入口（`make help` で一覧表示） |
 | `scripts/` | セットアップスクリプト本体（`scripts/linux/` は Linux 専用） |
 | `mac/scripts/` | macOS 専用スクリプト（Xcode CLT インストールなど） |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,25 @@
+# ドキュメント
+
+各ツールの操作方法・プラグインの使い方をまとめています。セットアップ手順(ワンライナーインストール、`make` ターゲット一覧)はリポジトリルートの [README.md](../README.md) を参照してください。
+
+| ドキュメント | 内容 |
+|---|---|
+| [tmux.md](tmux.md) | tmux のキーバインド、プラグイン(resurrect / continuum / vim-tmux-navigator 等)の使い方 |
+| [zsh.md](zsh.md) | zsh の構成、エイリアス、fzf / zoxide / fzf-git などのコマンド拡張 |
+| [fish.md](fish.md) | fish の構成、tide / fzf.fish プラグインの使い方 |
+| [nvim.md](nvim.md) | Neovim のキーマップ一覧、プラグインの使い方、LSP の構成 |
+| [git.md](git.md) | git エイリアス一覧、delta、会社用 gitconfig の分離設定 |
+| [terminal.md](terminal.md) | WezTerm / Ghostty / iTerm2 の設定とテーマ |
+
+## 設定ファイルとドキュメントの対応
+
+| ドキュメント | 設定ファイル |
+|---|---|
+| tmux.md | `configs/tmux/tmux.conf` |
+| zsh.md | `configs/zsh/zshrc`, `configs/zsh/shoichi/*.zsh`, `configs/starship/starship.toml` |
+| fish.md | `configs/fish/config/fish/`, `configs/fish/fish_plugins` |
+| nvim.md | `configs/nvim/` |
+| git.md | `configs/git/gitconfig`, `configs/git/gitignore_global` |
+| terminal.md | `configs/wezterm/`, `configs/ghostty/`, `configs/iterm2/`, `iterm/` |
+
+設定を変更する場合はこのリポジトリの `configs/` 配下を編集してください(`make link` でデプロイした環境では symlink 経由で即反映されます)。ドキュメントと設定が乖離しないよう、設定変更時は対応するドキュメントも更新してください。

--- a/docs/fish.md
+++ b/docs/fish.md
@@ -1,0 +1,57 @@
+# fish
+
+設定ファイル: `configs/fish/config/fish/`(→ `~/.config/fish/`)、プラグイン定義: `configs/fish/fish_plugins`
+
+セットアップ: `make fish`(fish 本体 + fisher + プラグインをインストール)
+
+## 構成
+
+`config.fish` の読み込み順:
+
+1. 基本設定(greeting 無効化、`EDITOR=nvim`)
+2. `shoichi/alias.fish` — エイリアス
+3. `shoichi/path.fish` — PATH と fzf 設定
+4. OS 別設定(`config-osx.fish` / `config-linux.fish` / `config-windows.fish`)
+5. `config-local.fish` — **git 管理外のローカル設定**(存在すれば読み込み。マシン固有の設定はここに置く)
+
+## プラグイン(fisher 管理)
+
+`fish_plugins` に定義。`fisher update` で同期されます。
+
+### tide(プロンプト)
+
+[ilancosman/tide](https://github.com/IlanCosman/tide) v6。初回またはメジャーアップデート後は対話ウィザードで見た目を設定します:
+
+```fish
+tide configure
+```
+
+### fzf.fish(あいまい検索)
+
+[PatrickF1/fzf.fish](https://github.com/PatrickF1/fzf.fish)。主なキーバインド:
+
+| キー | 動作 |
+|---|---|
+| `Ctrl+Alt+F` | ファイル検索(プレビュー付き) |
+| `Ctrl+R` | コマンド履歴検索 |
+| `Ctrl+Alt+L` | git log 検索 |
+| `Ctrl+Alt+S` | git status のファイル検索 |
+| `Ctrl+Alt+P` | プロセス検索(kill に便利) |
+| `Ctrl+V` | シェル変数検索 |
+
+> 旧プラグイン(jethrokuan/fzf)とはキーバインドが異なります。`fzf_configure_bindings` で変更可能です。
+
+## エイリアス
+
+| エイリアス | 実体 |
+|---|---|
+| `ls` | `ls -p -G` |
+| `la` / `ll` / `lla` | `ls -A` / `ls -l` / `ll -A` |
+| `ll`(macOS で exa がある場合) | `exa -l -g --icons` |
+| `g` | `git` |
+
+## PATH / ツール連携(`path.fish`)
+
+- `~/bin`、`~/.local/bin`、Go(`$GOPATH/bin`)を PATH に追加
+- fzf のファイル列挙は zsh と同じく `fd` ベース(隠しファイル込み、`.git` 除外)
+- macOS では rbenv 初期化、Homebrew shellenv、diff-highlight の PATH 追加(Apple Silicon / Intel 両対応)

--- a/docs/git.md
+++ b/docs/git.md
@@ -1,0 +1,76 @@
+# git
+
+設定ファイル: `configs/git/gitconfig`(→ `~/.gitconfig`)、`configs/git/gitignore_global`(→ `~/.gitignore_global`)
+
+- エディタ: nvim
+- pager / diff: **delta**(構文ハイライト付き side-by-side 表示。`n` / `N` でファイル間を移動)
+- `pull.rebase = true`(pull は常に rebase)
+- `push.autoSetupRemote = true`(初回 push で upstream を自動設定)
+- `init.defaultBranch = main`
+
+## エイリアス一覧
+
+`g` が `git` のエイリアスなので `g st` のように使えます(zsh / fish 共通)。
+
+### 日常操作
+
+| エイリアス | 実体 | 説明 |
+|---|---|---|
+| `st` | `status` | |
+| `d` | `diff` | delta で表示 |
+| `b` | `branch` | |
+| `ch` | `checkout` | |
+| `cm` | `commit` | |
+| `ca` | `!git add -A && git commit` | 全変更をステージしてコミット |
+| `amend` | `commit --amend` | 直前のコミットを修正 |
+| `unstage` | `reset HEAD --` | ステージ取り消し |
+| `pl` | `pull` | |
+| `ph` | `!git push -u origin HEAD` | 現在のブランチを upstream 設定付きで push |
+| `lg` | `log --oneline --graph --decorate --all` | 全ブランチのグラフ表示 |
+
+### GitHub 連携(gh CLI)
+
+| エイリアス | 説明 |
+|---|---|
+| `open` / `o` | 現在のリポジトリをブラウザで開く |
+| `pr` | プルリクエストを作成(ブラウザで開く) |
+| `pp` | プルリクエストを編集 |
+| `showpr <branch>` | 指定ブランチが最初にマージされた PR を表示 |
+| `openpr <branch>` | 指定ブランチが最初にマージされた PR をブラウザで開く |
+
+### ブランチ / スタッシュ / その他
+
+| エイリアス | 説明 |
+|---|---|
+| `track` | 現在のブランチをリモートの同名ブランチに追跡設定 |
+| `delete-branch <name>` | ブランチ削除(`-d`) |
+| `fetch-all` / `pull-all` | 全リモートの fetch / pull |
+| `stash-all` | 未追跡ファイル込みでスタッシュ |
+| `stash-pop` / `stash-list` | スタッシュの取り出し / 一覧 |
+| `resolve` | mergetool(vimdiff)でコンフリクト解決してコミット |
+| `rebase-continue` | rebase を続行 |
+
+## user.name / user.email の設定
+
+`~/.gitconfig` に user 情報はコミットされていません。`make link` / `make copy` 時に `setup-gitconfig.sh` が対話で設定します:
+
+- 対話モード: 直近コミットの著者をデフォルト値として確認プロンプト
+- `DOTFILES_GIT_USER_NAME` / `DOTFILES_GIT_USER_EMAIL` 指定時: その値を使用
+- `NONINTERACTIVE=1`: 既存の global 設定を維持(なければスキップ)
+
+## 会社用 gitconfig の分離
+
+`make link` 実行時に「COMPANY USER INFO を設定するか」を聞かれます。`y` にすると:
+
+1. `~/workspace/<会社名>/.<会社名>.gitconfig` に会社用の user.name / user.email を書き込み
+2. `~/.gitconfig` に `includeIf "gitdir:~/workspace/<会社名>/"` を追加
+
+これにより **`~/workspace/<会社名>/` 配下のリポジトリだけ会社のメールアドレスでコミット**されます。個人リポジトリは global 設定のまま。
+
+## gitignore_global
+
+全リポジトリ共通で無視されるパターン(`core.excludesFile`):
+
+- `*~`、`.DS_Store`
+- `**/.claude/*`(ただし `**/.claude/commands/` は除外しない)
+- Firebase CLI のログ / キャッシュ(`*-debug.log`、`.firebase/`)

--- a/docs/nvim.md
+++ b/docs/nvim.md
@@ -1,0 +1,156 @@
+# Neovim
+
+設定ファイル: `configs/nvim/`(→ `~/.config/nvim/`)
+
+- プラグインマネージャ: [lazy.nvim](https://github.com/folke/lazy.nvim)(初回起動時に自動インストール)
+- カラースキーム: tokyonight(night スタイル、coolnight 風にカスタム)
+- **リーダーキー: `Space`**
+
+## 管理コマンド
+
+| コマンド | 動作 |
+|---|---|
+| `:Lazy` | プラグインの管理画面(インストール / 更新 / 削除) |
+| `:Mason` | LSP サーバー・フォーマッタ・リンタの管理画面 |
+| `:TSUpdate` | treesitter パーサーの更新 |
+
+## 基本キーマップ(`core/keymaps.lua`)
+
+| キー | モード | 動作 |
+|---|---|---|
+| `jk` | 挿入 | ノーマルモードに戻る(ESC 相当) |
+| `<Space>nh` | ノーマル | 検索ハイライトを消す |
+| `<Space>+` / `<Space>-` | ノーマル | カーソル下の数値をインクリメント / デクリメント |
+
+### ウィンドウ / タブ
+
+| キー | 動作 |
+|---|---|
+| `<Space>sv` / `<Space>sh` | 縦分割 / 横分割 |
+| `<Space>se` | 分割サイズを均等化 |
+| `<Space>sx` | 現在の分割を閉じる |
+| `<Space>sm` | 分割の最大化トグル(vim-maximizer) |
+| `Ctrl+h/j/k/l` | ウィンドウ間移動(tmux ペインともシームレス) |
+| `<Space>to` / `<Space>tx` | タブを開く / 閉じる |
+| `<Space>tn` / `<Space>tp` | 次 / 前のタブ |
+| `<Space>tf` | 現在のバッファを新規タブで開く |
+
+タブは bufferline によりエディタ上部にスラント区切りで表示されます。
+
+## ファイル操作
+
+### Telescope(あいまい検索)
+
+| キー | 動作 |
+|---|---|
+| `<Space>ff` | ファイル検索 |
+| `<Space>fr` | 最近開いたファイル |
+| `<Space>fs` | 全文検索(live grep) |
+| `<Space>fc` | カーソル下の文字列で全文検索 |
+| `<Space>ft` | TODO コメント検索 |
+
+検索結果内: `Ctrl+k/j` で上下移動、`Ctrl+q` で選択を quickfix に送って Trouble で開く。
+
+### nvim-tree(ファイルエクスプローラ)
+
+| キー | 動作 |
+|---|---|
+| `<Space>ee` | ツリーの表示 / 非表示 |
+| `<Space>ef` | 現在のファイル位置でツリーを開く |
+| `<Space>ec` | ツリーを全部折りたたむ |
+| `<Space>er` | ツリーを再読み込み |
+
+## LSP(`plugins/lsp/`)
+
+Mason が LSP サーバーを自動インストールし(`:Mason` で確認)、対応言語: TypeScript / HTML / CSS / Tailwind / Svelte / Lua / GraphQL / Emmet / Prisma / Python / Go / Terraform / Kotlin / Swift(sourcekit) / JSON / YAML / Protobuf / Bash / Docker / Markdown / Rust / C・C++ / TOML / SQL。
+
+バッファに LSP がアタッチされると以下が有効になります:
+
+| キー | 動作 |
+|---|---|
+| `gd` / `gD` | 定義 / 宣言へジャンプ |
+| `gR` | 参照一覧(Telescope) |
+| `gi` / `gt` | 実装 / 型定義一覧 |
+| `K` | ホバードキュメント表示 |
+| `<Space>ca` | コードアクション |
+| `<Space>rn` | シンボルのリネーム |
+| `<Space>d` / `<Space>D` | 行 / バッファの診断表示 |
+| `[d` / `]d` | 前 / 次の診断へジャンプ(フロート表示付き) |
+| `<Space>rs` | LSP 再起動 |
+
+### 補完(nvim-cmp)
+
+挿入モードで自動表示。LSP / スニペット(LuaSnip + friendly-snippets)/ バッファ / パスが補完ソース。
+
+| キー | 動作 |
+|---|---|
+| `Ctrl+j` / `Ctrl+k` | 候補の選択(下 / 上) |
+| `Enter` | 確定 |
+| `Ctrl+Space` | 補完を手動で表示 |
+| `Ctrl+e` | 補完ウィンドウを閉じる |
+| `Ctrl+f` / `Ctrl+b` | ドキュメントのスクロール |
+
+### フォーマット / リント
+
+- **conform.nvim**: `<Space>mp` でファイル(ビジュアルモードでは範囲)をフォーマット。prettier / stylua / isort / black など
+- **nvim-lint**: 保存時に自動リント。`<Space>l` で手動実行。eslint_d / pylint など
+
+> 注意: `<Space>mp` は markview(Markdown プレビュー)のトグルにも割り当てられており、**キーが重複しています**。Markdown ファイルでの挙動は後から読み込まれた方が優先されます。
+
+## Git 連携
+
+### gitsigns(ハンク操作)
+
+| キー | 動作 |
+|---|---|
+| `]h` / `[h` | 次 / 前の変更ハンクへ |
+| `<Space>hs` / `<Space>hr` | ハンクをステージ / リセット(ビジュアルモード対応) |
+| `<Space>hS` / `<Space>hR` | バッファ全体をステージ / リセット |
+| `<Space>hu` | ステージの取り消し |
+| `<Space>hp` | ハンクのプレビュー |
+| `<Space>hb` | 行の blame 表示 |
+| `<Space>hB` | 行 blame の常時表示トグル |
+| `<Space>hd` | diff 表示 |
+
+### lazygit
+
+`<Space>lg` で lazygit を開く(要 `brew "lazygit"`)。
+
+## 編集系プラグイン
+
+| プラグイン | 使い方 |
+|---|---|
+| Comment.nvim | `gcc` で行コメント、`gc` + モーション(例: `gc3j`)、ビジュアル選択で `gc`。JSX/TSX 対応 |
+| nvim-surround | `ys<motion><char>` で囲む(例: `ysiw"`)、`ds<char>` で削除、`cs<old><new>` で変更 |
+| substitute.nvim | `s<motion>` でレジスタ内容と置き換え(例: `siw`)、`ss` で行、`S` で行末まで |
+| nvim-autopairs | 括弧・クォートの自動補完(treesitter 連携) |
+| nvim-ts-autotag | HTML/JSX タグの自動クローズ・リネーム |
+| todo-comments | `TODO:` `FIX:` 等をハイライト。`]t` / `[t` で移動、`<Space>ft` で一覧 |
+| indent-blankline | インデントガイド表示 |
+| markview | Markdown のインラインプレビュー。`<Space>ms` で分割プレビュー |
+
+## 診断一覧(Trouble)
+
+| キー | 動作 |
+|---|---|
+| `<Space>xw` | ワークスペース全体の診断一覧 |
+| `<Space>xd` | 現在バッファの診断一覧 |
+| `<Space>xq` | quickfix リスト |
+| `<Space>xl` | location リスト |
+| `<Space>xt` | TODO 一覧 |
+
+## セッション管理(auto-session)
+
+| キー | 動作 |
+|---|---|
+| `<Space>wr` | カレントディレクトリのセッションを復元 |
+| `<Space>ws` | セッションを保存 |
+
+`~/` `~/Downloads` などトップレベルディレクトリでは自動復元されません。
+
+## その他
+
+- **alpha**: 引数なしで `nvim` を起動するとダッシュボードを表示
+- **which-key**: `<Space>` を押して 500ms 待つと、続けて押せるキーの一覧がポップアップ表示される(キーマップを忘れたときに便利)
+- **lualine**: ステータスライン(lazy.nvim の更新通知も表示)
+- クリップボードはシステムと共有(`unnamedplus`)

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -1,0 +1,42 @@
+# ターミナル(WezTerm / Ghostty / iTerm2)
+
+3つのターミナルすべてに **coolnight カラーテーマ**(ダークブルー背景 `#011423` 系)を適用しています。Neovim の tokyonight カスタムも同系色で、ターミナルとエディタの見た目が揃います。
+
+フォントはいずれも Nerd Font(starship / p10k のアイコン表示に必要)。`make bootstrap` の Brewfile で `font-hack-nerd-font` / `font-meslo-lg-nerd-font` がインストールされます。
+
+## WezTerm
+
+設定: `configs/wezterm/wezterm.lua`(→ `~/.config/wezterm/`)
+
+- フォント: MesloLGS Nerd Font Mono 13pt
+- coolnight カラー(ANSI 16色 + カーソル / 選択色)
+- 背景の透過 75% + ブラー(macOS)
+- ウィンドウ装飾は RESIZE のみ(タイトルバーなし)
+
+## Ghostty
+
+設定: `configs/ghostty/config`(→ `~/.config/ghostty/`)
+
+- フォント: Hack Nerd Font Mono 13pt
+- coolnight カラー(WezTerm から移植)
+- 背景の透過 75% + ブラー
+- `Shift+Enter` で改行を入力(`\x1b\r` を送信。Claude Code などの複数行入力用)
+- `window-vsync = false`(スリープ復帰時の文字化け対策)
+
+プロンプトのアイコンが `?` に化ける場合は Ghostty を完全再起動してください(フォントキャッシュの再読み込み)。
+
+## iTerm2
+
+- 設定 plist: `configs/iterm2/com.googlecode.iterm2.plist` — `make link` / `make copy` で `~/Library/Preferences/` に自動配置されます(iTerm2 の再起動後に反映)
+- カラーテーマ: `iterm/theme/coolnight.itermcolors` — 手動インポートが必要です:
+  1. iTerm2 の Settings > Profiles > Colors を開く
+  2. 右下の Color Presets... > Import... で `iterm/theme/coolnight.itermcolors` を選択
+  3. Color Presets... から coolnight を選択
+
+詳細は [iterm/README.md](../iterm/README.md) を参照。
+
+## テーマに関する補足
+
+coolnight の元テーマは ANSI color 7(白)がシアン(`#24EAF7`)に設定されていましたが、白系文字が正しく明色で表示されるよう wezterm / ghostty では修正済みです(通常白: `#CBE0F0`、明るい白: `#FFFFFF`)。
+
+True color は tmux 側でも全ターミナル向けに有効化しています(`docs/tmux.md` 参照)。

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -1,0 +1,87 @@
+# tmux
+
+設定ファイル: `configs/tmux/tmux.conf`(`make link` で `~/.tmux.conf` に配置)
+
+## 基本
+
+- **プレフィックスキー: `Ctrl+Space`**(デフォルトの `Ctrl+b` から変更済み)
+- マウス操作有効(ペイン選択、リサイズ、スクロール)
+- True color / undercurl 対応(全ターミナル)
+- 履歴バッファ 50,000 行
+
+## キーバインド一覧
+
+以下、`prefix` = `Ctrl+Space`。
+
+### ペイン操作
+
+| キー | 動作 |
+|---|---|
+| `prefix` `\|` | 縦分割(現在のディレクトリを引き継ぐ) |
+| `prefix` `-` | 横分割(現在のディレクトリを引き継ぐ) |
+| `Ctrl+h / j / k / l` | ペイン間移動(**prefix 不要**。vim-tmux-navigator により vim/nvim のウィンドウともシームレスに移動) |
+| `prefix` `h / j / k / l` | ペインのリサイズ(5セルずつ。リピート可: prefix を押し直さず連打できる) |
+| `prefix` `m` | ペインの最大化 / 元に戻す(トグル) |
+
+### コピーモード(vi キーバインド)
+
+| キー | 動作 |
+|---|---|
+| `prefix` `[` | コピーモード開始 |
+| `v` | 選択開始 |
+| `y` | 選択範囲をコピー |
+| `q` | コピーモード終了 |
+
+- マウスドラッグで選択してもコピーモードは終了しません(継続して操作可能)
+- マウスホイールのスクロールは1行単位
+
+### その他
+
+| キー | 動作 |
+|---|---|
+| `prefix` `r` | `~/.tmux.conf` を再読み込み |
+
+## セッション / ウィンドウの命名
+
+セッション名・ウィンドウ名は **zsh の precmd フックが現在のディレクトリ名で自動リネーム**します(`configs/zsh/zshrc` 参照)。tmux 側の `automatic-rename` / `allow-rename` は無効化してあります。ディレクトリを移動したときだけリネームされます。
+
+また、新規セッション作成時に自動で縦分割されます(`session-created` フック)。
+
+## プラグイン
+
+TPM(Tmux Plugin Manager)で管理。`make tmux` 実行時に隔離サーバー上で自動インストールされます(稼働中のセッションには影響しません)。
+
+| プラグイン | 用途 |
+|---|---|
+| [vim-tmux-navigator](https://github.com/christoomey/vim-tmux-navigator) | `Ctrl+h/j/k/l` で tmux ペインと vim/nvim ウィンドウを区別なく移動 |
+| [tmux-resurrect](https://github.com/tmux-plugins/tmux-resurrect) | セッション(ペイン構成・作業ディレクトリ・ペイン内容)の保存と復元 |
+| [tmux-continuum](https://github.com/tmux-plugins/tmux-continuum) | resurrect の**15分ごとの自動保存**と、tmux 起動時の**自動復元**(`@continuum-restore 'on'`) |
+| [tmux-mem-cpu-load](https://github.com/thewtex/tmux-mem-cpu-load) | ステータスバー左側に CPU / メモリ使用率を表示(2秒間隔) |
+
+### TPM の操作
+
+| キー | 動作 |
+|---|---|
+| `prefix` `I` | プラグインのインストール |
+| `prefix` `U` | プラグインのアップデート |
+| `prefix` `Alt+u` | 設定から削除したプラグインのアンインストール |
+
+### resurrect の手動操作
+
+| キー | 動作 |
+|---|---|
+| `prefix` `Ctrl+s` | セッションを保存 |
+| `prefix` `Ctrl+r` | 保存したセッションを復元 |
+
+通常は continuum が自動保存・自動復元するため手動操作は不要です。
+
+## ユーティリティ: clean-tmux
+
+`bin/clean-tmux`(`make link` で `~/.local/bin/clean-tmux` に配置)は、全セッションの kill と resurrect の保存データ(`~/.tmux/resurrect/`)の削除を行います。
+
+```bash
+clean-tmux          # 確認プロンプトあり
+clean-tmux --force  # 確認なしで実行
+```
+
+保存済みセッションが壊れて復元がおかしくなった場合のリセットに使います。**非可逆な操作**なので注意してください。

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -1,0 +1,93 @@
+# zsh
+
+設定ファイル: `configs/zsh/zshrc`(→ `~/.zshrc`)と `configs/zsh/shoichi/*.zsh`(→ `~/.config/zsh/shoichi/`)
+
+## 構成
+
+読み込み順(`zshrc`):
+
+1. 基本設定(`EDITOR=nvim`、emacs キーバインド、`LANG=ja_JP.UTF-8`)
+2. プロンプト初期化(デフォルト: **starship**)
+3. OS 別設定(`config-osx.zsh` / `config-linux.zsh`)
+4. 補完初期化(`compinit`)
+5. `command-extensions.zsh`(fzf / bat / thefuck など)
+6. `alias.zsh`
+7. tmux 自動リネーム、direnv、PATH
+8. **zoxide 初期化(必ず末尾)**
+
+### プロンプトの切り替え
+
+`zshrc` の `prompt_type` を変更します:
+
+- `starship`(デフォルト): 設定は `configs/starship/starship.toml`。OS アイコン、git ブランチ/ステータス/差分行数、言語バージョン(swift / terraform / lua / python / node)、AWS プロファイル、docker context、コマンド実行時間、現在時刻を表示
+- `oh-my-zsh`: `shoichi/oh-my-zsh.zsh` 経由で oh-my-zsh + powerlevel10k を使用(`make zsh` でインストールされる)
+
+## エイリアス(`alias.zsh`)
+
+| エイリアス | 実体 | 説明 |
+|---|---|---|
+| `ls` / `l` | `eza --color=always --long --git --icons=always --no-user` | git ステータス・アイコン付きの一覧 |
+| `lt` | `ls --tree` | ツリー表示 |
+| `la` | `ls --all` | 隠しファイル込み |
+| `lat` | `ls --all --tree` | 隠しファイル込みツリー |
+| `g` | `git` | |
+
+## コマンド拡張(`command-extensions.zsh`)
+
+### fzf(ファジーファインダー)
+
+ファイル列挙は `fd` ベース(隠しファイル込み、`.git` 除外)。
+
+| キー | 動作 |
+|---|---|
+| `Ctrl+T` | ファイルをあいまい検索して挿入(**bat によるプレビュー付き**) |
+| `Ctrl+R` | コマンド履歴をあいまい検索 |
+| `Alt+C` | ディレクトリをあいまい検索して cd(**eza ツリープレビュー付き**) |
+| `**` + `Tab` | パス補完をあいまい検索(例: `vim **<Tab>`、`cd **<Tab>`、`ssh **<Tab>`) |
+
+### fzf-git(git オブジェクトのあいまい検索)
+
+シェル上で `Ctrl+G` に続けて以下を押すと、対応する git オブジェクトを fzf で検索して挿入できます:
+
+| キー | 対象 |
+|---|---|
+| `Ctrl+G` `Ctrl+F` | 変更ファイル(git status) |
+| `Ctrl+G` `Ctrl+B` | ブランチ |
+| `Ctrl+G` `Ctrl+T` | タグ |
+| `Ctrl+G` `Ctrl+H` | コミットハッシュ(log) |
+| `Ctrl+G` `Ctrl+R` | リモート |
+| `Ctrl+G` `Ctrl+S` | スタッシュ |
+| `Ctrl+G` `Ctrl+L` | reflog |
+| `Ctrl+G` `Ctrl+W` | worktree |
+
+例: `git rebase -i ` まで打って `Ctrl+G` `Ctrl+H` でコミットを選択。
+
+### zoxide(スマートな cd)
+
+`zoxide init zsh --cmd cd` により **`cd` コマンド自体が置き換わっています**:
+
+```bash
+cd foo        # 過去に訪れたディレクトリを頻度順にあいまいマッチしてジャンプ
+cd foo bar    # 複数キーワードで絞り込み
+cdi           # fzf で対話的に選択
+cd -          # 直前のディレクトリへ
+```
+
+通常のパス指定(`cd ./dir`、`cd /absolute/path`)もそのまま動きます。
+
+### その他
+
+- **bat**: `BAT_THEME=tokyonight_night`(テーマは `make zsh_extensions` でインストール。未インストール環境では自動的にデフォルトテーマになる)
+- **thefuck**(macOS のみ): 直前のコマンドの typo を `fuck` または `fk` で修正
+- **direnv**: ディレクトリ移動時に `.envrc` を自動読み込み
+- **zsh-autosuggestions**: 履歴ベースの薄色サジェストを `→`(または `End`)で確定
+- **zsh-syntax-highlighting**: コマンドラインのリアルタイム構文ハイライト
+
+## tmux セッションの自動リネーム
+
+tmux 内でディレクトリを移動すると、セッション名・ウィンドウ名が**ディレクトリ名に自動で変わります**(precmd フック。同じディレクトリにいる間は再実行されないため、手動リネームは次の移動まで維持されます)。
+
+## インストール関連
+
+- `make zsh`: zsh 本体 + oh-my-zsh + powerlevel10k / omz 用プラグイン
+- `make zsh_extensions`: fzf-git、bat テーマ、zsh-autosuggestions / zsh-syntax-highlighting(starship 経路用、`~/.zsh/` 配下)

--- a/iterm/README.md
+++ b/iterm/README.md
@@ -1,4 +1,17 @@
 # iTerm2 settings
 
-## import the setting from dotfiles
-Open setting > General > Settings > click 'Import All Settings and Data' > choose 'iTerm2 State.itermexport
+## 設定の反映方法
+
+### 1. 設定 plist(自動)
+
+`configs/iterm2/com.googlecode.iterm2.plist` が `make link` / `make copy` で
+`~/Library/Preferences/com.googlecode.iterm2.plist` に配置されます。
+iTerm2 を再起動すると反映されます。
+
+### 2. カラーテーマ(手動インポート)
+
+`theme/coolnight.itermcolors` は手動でインポートします:
+
+1. iTerm2 の Settings > Profiles > Colors を開く
+2. 右下の Color Presets... > Import... で `theme/coolnight.itermcolors` を選択
+3. Color Presets... のリストから coolnight を選択


### PR DESCRIPTION
## 概要

`docs/` ディレクトリを新設し、各ツールの操作方法・キーバインド・プラグインの使い方をドキュメント化しました。すべて実際の設定ファイル(`configs/`)を読んで記載しており、記述と設定の対応表を index に含めています。

## 追加ドキュメント

| ファイル | 内容 |
|---|---|
| `docs/README.md` | index。各ドキュメントと設定ファイルの対応表 |
| `docs/tmux.md` | プレフィックス(`Ctrl+Space`)、ペイン操作、コピーモード、TPM プラグイン4種の使い方、resurrect の手動保存/復元、`clean-tmux` |
| `docs/zsh.md` | 設定の読み込み順、プロンプト切り替え(starship / oh-my-zsh)、eza エイリアス、fzf(`Ctrl+T`/`Ctrl+R`/`Alt+C`/`**<Tab>`)、fzf-git(`Ctrl+G` 系)、zoxide の cd 置き換え、tmux 自動リネームの挙動 |
| `docs/fish.md` | tide v6(`tide configure`)、fzf.fish のキーバインド、`config-local.fish` の慣習 |
| `docs/nvim.md` | 全キーマップリファレンス(コア / Telescope / nvim-tree / LSP / 補完 / gitsigns / Trouble / 編集系)、`:Lazy` `:Mason` 等の管理コマンド、対応言語一覧 |
| `docs/git.md` | エイリアス全一覧(日常操作 / gh 連携 / ブランチ・スタッシュ)、delta、identity 設定フロー、includeIf による会社用設定の分離 |
| `docs/terminal.md` | WezTerm / Ghostty / iTerm2 の coolnight テーマと各設定 |

## あわせて修正

- **ルート README**: 冒頭に docs/ への案内を追加、ディレクトリ構成表に docs/ を追記
- **iterm/README.md**: PR #37 で削除済みの `iTerm2 State.itermexport` を参照する古い手順を、実態(plist は `make link` で自動配置、カラーテーマのみ手動インポート)に書き換え(2巡目レビュー指摘 #16 の対応)

## 検証

- 全ドキュメントの相対リンク切れなしを確認
- キーバインドは configs/ の実設定(tmux.conf、keymaps.lua、各プラグイン設定、gitconfig 等)から転記
- ドキュメント化の過程で発見: nvim の `<Space>mp` が conform(フォーマット)と markview(プレビュー)で**重複**しています。docs には注記済み。修正は別PRで対応可能です

🤖 Generated with [Claude Code](https://claude.com/claude-code)