### PR TITLE
Support Bazzite (Fedora Atomic) for the Linux setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,11 +129,17 @@ bootstrap b: check-sudo
 .PHONY: Linux_setup
 Linux_setup: check-sudo
 	@echo "" && echo "=== Linux Setup ==="
+	# apt 系ディストリのみ: Homebrew on Linux の前提パッケージを導入
+	# (https://docs.brew.sh/Homebrew-on-Linux)
+	# Fedora Atomic 系 (Bazzite 等) は brew 同梱・前提不要のためスキップ。
 	# NOTE: apt-get upgrade は行わない。bootstrap に不要な上、
 	# needrestart / conffile の対話ダイアログで非対話実行が停止し得るため
-	sudo -n apt-get update
-	# Homebrew on Linux の前提パッケージ (https://docs.brew.sh/Homebrew-on-Linux)
-	sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential procps curl file git
+	@if command -v apt-get >/dev/null 2>&1; then \
+		sudo -n apt-get update; \
+		sudo -n DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential procps curl file git; \
+	else \
+		echo "apt-get not found (Fedora Atomic / Bazzite?); skipping apt prerequisites."; \
+	fi
 	$(MAKE) linux_support_japanese
 	$(MAKE) brew_install
 	$(MAKE) brew_setup

--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ bash <(curl -sL https://raw.githubusercontent.com/syouit523/dotfiles-public/main
 - GUI アプリ（Flatpak 経由の WezTerm など）は含まれません。必要なら別途 `make linux_gui_setup` を実行してください
 - 動作は GitHub Actions（Linux Bootstrap Test）で Ubuntu 実機相当を使って検証しています
 
+#### Bazzite（Fedora Atomic 系）での利用
+
+Bazzite / Fedora Atomic 系（ostree ベース）でも同じワンライナーが使えます。apt の代わりに以下の挙動になります:
+
+- **Homebrew はイメージ同梱**のためインストールをスキップ。前提として不足する `make` だけ brew で自動調達します（`gmake` として導入され、init.sh がフォールバックします）
+- **日本語設定**はシステムロケールの設定のみ（`glibc-all-langpacks`・Noto CJK フォント・mozc はイメージ同梱）
+- **tailscale はイメージ同梱**のためインストールをスキップ。有効化は `ujust enable-tailscale`
+- **login shell は変更されません**。Fedora Atomic では brew のシェルを login shell にすることが公式に非推奨のため、代わりにターミナル（Ptyxis）のプロファイルで起動シェルを設定してください: Settings > Profiles > Custom Command に `/home/linuxbrew/.linuxbrew/bin/zsh`
+- CI での自動検証は Ubuntu のみです。Bazzite 側の検証は実機 / VM で行ってください
+
 ### 対話モード（従来）
 
 環境変数を渡さない場合は対話モードで実行されます:

--- a/scripts/change-default-shell.sh
+++ b/scripts/change-default-shell.sh
@@ -4,6 +4,10 @@
 # 通常実行時は /etc/shells を見る。
 SHELLS_FILE="${SHELLS_FILE:-/etc/shells}"
 
+# ostree ベース (Fedora Atomic / Bazzite 等) の判定マーカー。
+# テストから差し替えられるよう環境変数化している。
+OSTREE_BOOTED_FILE="${OSTREE_BOOTED_FILE:-/run/ostree-booted}"
+
 select_shell_noninteractive() {
   local target="$1"
   # フルパス指定にも対応（/bin/zsh → zsh に正規化してから検索）
@@ -77,16 +81,40 @@ else
   selected_shell="${shells[$((choice - 1))]}"
 fi
 
-if [ -n "$selected_shell" ]; then
-  if sudo -n chsh -s "$selected_shell" "$USER"; then
-    echo "Default shell changed to $selected_shell"
-    echo "You need to log out and log back in for changes to take effect"
-  else
-    echo "Failed to change shell to $selected_shell" >&2
-    echo "Hint: ensure sudo cache is active (run 'make check-sudo' first)" >&2
-    exit 1
-  fi
-else
+if [ -z "$selected_shell" ]; then
   echo "Invalid selection" >&2
+  exit 1
+fi
+
+# Fedora Atomic (Bazzite 等、ostree ベース) では brew 導入シェルを
+# login shell にすることが公式に非推奨とされている
+# (システムが起動不能になる報告あり: ublue-os/bazzite#4159)。
+# 自動変更はせず、ターミナルエミュレータ側での設定を案内する。
+if [ -f "$OSTREE_BOOTED_FILE" ]; then
+  case "$selected_shell" in
+    /home/linuxbrew/*|/var/home/linuxbrew/*)
+      echo "Detected ostree-based OS (Fedora Atomic / Bazzite)."
+      echo "Changing the login shell to a Homebrew shell is not recommended here."
+      echo "Instead, configure your terminal emulator to launch it, e.g. Ptyxis:"
+      echo "  Settings > Profiles > Custom Command: $selected_shell"
+      echo "Skipping login shell change."
+      exit 0
+      ;;
+  esac
+fi
+
+# chsh は Fedora 系に同梱されないため usermod にフォールバックする
+if command -v chsh >/dev/null 2>&1; then
+  change_cmd=(sudo -n chsh -s "$selected_shell" "$USER")
+else
+  change_cmd=(sudo -n usermod --shell "$selected_shell" "$USER")
+fi
+
+if "${change_cmd[@]}"; then
+  echo "Default shell changed to $selected_shell"
+  echo "You need to log out and log back in for changes to take effect"
+else
+  echo "Failed to change shell to $selected_shell" >&2
+  echo "Hint: ensure sudo cache is active (run 'make check-sudo' first)" >&2
   exit 1
 fi

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -8,22 +8,43 @@ TARGET_DIR="$HOME/workspace/dotfiles-public"
 # Linux: 素の環境には git / make / curl が無いことがあるため先にインストールする
 # (macOS は README のワンライナーで xcode-select --install 済みの前提)
 if [ "$(uname -s)" = "Linux" ]; then
-    missing=""
-    for cmd in git make curl; do
-        command -v "$cmd" >/dev/null 2>&1 || missing="$missing $cmd"
-    done
-    if [ "$(id -u)" -eq 0 ]; then
-        # root (素のコンテナ等) では sudo 自体が無いことがある。
-        # 後続の Makefile が sudo を使うため、sudo も併せて導入する
-        if [ -n "$missing" ] || ! command -v sudo >/dev/null 2>&1; then
-            echo "Installing prerequisites (as root):$missing sudo"
-            apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y git make curl sudo
+    if command -v apt-get >/dev/null 2>&1; then
+        # ---- apt 系 (Ubuntu 等) ----
+        missing=""
+        for cmd in git make curl; do
+            command -v "$cmd" >/dev/null 2>&1 || missing="$missing $cmd"
+        done
+        if [ "$(id -u)" -eq 0 ]; then
+            # root (素のコンテナ等) では sudo 自体が無いことがある。
+            # 後続の Makefile が sudo を使うため、sudo も併せて導入する
+            if [ -n "$missing" ] || ! command -v sudo >/dev/null 2>&1; then
+                echo "Installing prerequisites (as root):$missing sudo"
+                apt-get update
+                DEBIAN_FRONTEND=noninteractive apt-get install -y git make curl sudo
+            fi
+        elif [ -n "$missing" ]; then
+            echo "Installing prerequisites:$missing"
+            sudo apt-get update
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git make curl
         fi
-    elif [ -n "$missing" ]; then
-        echo "Installing prerequisites:$missing"
-        sudo apt-get update
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git make curl
+    else
+        # ---- apt が無いディストリ (Fedora Atomic / Bazzite 等) ----
+        # Bazzite は git / curl / Homebrew をイメージに同梱している。
+        # 不足するのは make だけなので brew で調達する
+        # (rpm-ostree レイヤリングは公式に最終手段とされるため使わない)
+        if ! command -v brew >/dev/null 2>&1 && [ -x /home/linuxbrew/.linuxbrew/bin/brew ]; then
+            eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        fi
+        if ! command -v make >/dev/null 2>&1 && ! command -v gmake >/dev/null 2>&1; then
+            if command -v brew >/dev/null 2>&1; then
+                echo "Installing make via Homebrew (non-apt distro)..."
+                brew install make  # GNU make は gmake として入る
+            else
+                echo "Error: neither apt-get nor Homebrew is available." >&2
+                echo "Supported: Ubuntu (apt) / Fedora Atomic with Homebrew (e.g. Bazzite)." >&2
+                exit 1
+            fi
+        fi
     fi
 fi
 
@@ -41,5 +62,11 @@ fi
 
 cd "$TARGET_DIR" || exit 1
 
+# brew の make は gmake という名前で入るため、make が無ければフォールバック
+MAKE_CMD="make"
+if ! command -v make >/dev/null 2>&1 && command -v gmake >/dev/null 2>&1; then
+    MAKE_CMD="gmake"
+fi
+
 echo "Setting up environment..."
-make bootstrap
+"$MAKE_CMD" bootstrap

--- a/scripts/linux/install-flatpak.sh
+++ b/scripts/linux/install-flatpak.sh
@@ -4,8 +4,17 @@ set -e
 
 # App Install Manager
 ## Install flatpak (PPA 追加後に1回だけインストールする)
-sudo add-apt-repository -y ppa:flatpak/stable
-sudo apt update
-sudo apt install flatpak -y
-sudo apt install gnome-software-plugin-flatpak -y
+## Fedora Atomic 系 (Bazzite 等) は flatpak + Flathub リモートが
+## 設定済みのため、インストール処理はスキップする
+if command -v apt-get >/dev/null 2>&1; then
+    sudo add-apt-repository -y ppa:flatpak/stable
+    sudo apt update
+    sudo apt install flatpak -y
+    sudo apt install gnome-software-plugin-flatpak -y
+elif command -v flatpak >/dev/null 2>&1; then
+    echo "flatpak is already available (non-apt distro). Skipping installation."
+else
+    echo "Error: no apt-get and no flatpak found. Install flatpak manually." >&2
+    exit 1
+fi
 flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo

--- a/scripts/linux/install-tailscale.sh
+++ b/scripts/linux/install-tailscale.sh
@@ -11,4 +11,13 @@ if command -v tailscale >/dev/null 2>&1; then
     exit 0
 fi
 
+# Fedora Atomic (Bazzite 等) では公式インストーラが使えない。
+# Bazzite は tailscale 同梱のため通常ここには到達しないが、
+# 他の ostree 系ディストリのための安全ガード。
+if [ -f /run/ostree-booted ]; then
+    echo "ostree-based OS detected. The official installer does not support it."
+    echo "Install tailscale via rpm-ostree or your distro's mechanism, then re-run."
+    exit 0
+fi
+
 curl -fsSL https://tailscale.com/install.sh | sh

--- a/scripts/linux/support-japanese.sh
+++ b/scripts/linux/support-japanese.sh
@@ -15,6 +15,24 @@ fi
 
 echo "日本語環境のセットアップを開始します..."
 
+# ---- apt が無いディストリ (Fedora Atomic / Bazzite 等) ----
+# Bazzite は glibc-all-langpacks (ja_JP ロケール)・Noto CJK フォント・
+# mozc (fcitx5/ibus) をイメージに同梱しているため、
+# 必要なのはシステムロケールの設定のみ。
+if ! command -v apt-get >/dev/null 2>&1; then
+  echo "apt 系ディストリではありません (Fedora Atomic / Bazzite?)。"
+  if command -v localectl >/dev/null 2>&1; then
+    echo "システムロケールを ja_JP.UTF-8 に設定します..."
+    localectl set-locale LANG=ja_JP.UTF-8
+    echo "設定しました。再ログインで反映されます。"
+  else
+    echo "localectl が見つかりません。手動でロケールを設定してください。"
+  fi
+  echo "(日本語フォント・mozc はイメージ同梱のためインストール不要です)"
+  exit 0
+fi
+
+# ---- 以下、apt 系 (Ubuntu) ----
 # 非対話実行時は dpkg の conffile プロンプト等も抑止する
 if [ "$NONINTERACTIVE" = "1" ]; then
   export DEBIAN_FRONTEND=noninteractive

--- a/tests/test_change_default_shell.bats
+++ b/tests/test_change_default_shell.bats
@@ -112,3 +112,51 @@ teardown() {
   [ "$status" -eq 1 ]
   [[ "$output" == *"Invalid selection"* ]]
 }
+
+@test "change-default-shell.sh: skips brew shell change on ostree-based OS (Bazzite)" {
+  # Fedora Atomic では brew シェルへの login shell 変更が公式非推奨のため、
+  # 案内を表示してスキップ (exit 0) する
+  SHELLS_FILE_WITH_BREW="$TEST_TEMP_DIR/shells_brew"
+  cat > "$SHELLS_FILE_WITH_BREW" <<'SHELLS'
+/bin/bash
+/home/linuxbrew/.linuxbrew/bin/zsh
+SHELLS
+  OSTREE_MARKER="$TEST_TEMP_DIR/ostree-booted"
+  touch "$OSTREE_MARKER"
+
+  run bash -c "
+    DOTFILES_DEFAULT_SHELL=zsh \
+    SHELLS_FILE='$SHELLS_FILE_WITH_BREW' \
+    OSTREE_BOOTED_FILE='$OSTREE_MARKER' \
+    '$SOURCE_SCRIPT' </dev/null 2>&1
+  "
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Skipping login shell change"* ]]
+}
+
+@test "change-default-shell.sh: ostree marker absent proceeds to the change command" {
+  # 非 ostree 環境では従来どおり chsh/usermod の実行パスに進む。
+  # 実際の sudo/chsh を呼ばないよう sudo をスタブして検証する
+  SHELLS_FILE_WITH_BREW="$TEST_TEMP_DIR/shells_brew2"
+  cat > "$SHELLS_FILE_WITH_BREW" <<'SHELLS'
+/home/linuxbrew/.linuxbrew/bin/zsh
+SHELLS
+  STUB_DIR="$TEST_TEMP_DIR/stub"
+  mkdir -p "$STUB_DIR"
+  printf '#!/bin/bash\necho "SUDO_STUB: $*"\nexit 1\n' > "$STUB_DIR/sudo"
+  chmod +x "$STUB_DIR/sudo"
+
+  run bash -c "
+    PATH='$STUB_DIR':\"\$PATH\" \
+    DOTFILES_DEFAULT_SHELL=zsh \
+    SHELLS_FILE='$SHELLS_FILE_WITH_BREW' \
+    OSTREE_BOOTED_FILE='$TEST_TEMP_DIR/no-such-marker' \
+    '$SOURCE_SCRIPT' </dev/null 2>&1
+  "
+
+  # スキップされず、変更コマンド (スタブ sudo) に到達している
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"SUDO_STUB:"* ]]
+  [[ "$output" != *"Skipping login shell change"* ]]
+}


### PR DESCRIPTION
## 概要

Bazzite(Fedora Atomic / ostree ベース)でも dotfiles をセットアップできるようにします。

事前調査(公式ドキュメント + Bazzite Containerfile / ublue-os リポジトリの一次ソース確認)で判明したとおり、Bazzite は **Homebrew・git・curl・tailscale・日本語ロケール/CJKフォント/mozc・Flatpak+Flathub をイメージに同梱**しており、PR #42 で brew ベースにした本セットアップとの相性は良好です。壊れるのは apt 依存箇所と chsh(Fedora系に不在)のみで、それらを分岐で対応しました。

## 変更内容

| 対象 | Bazzite での挙動 |
|---|---|
| `init.sh` | apt 不在ディストリでは同梱の brew を PATH に通し、唯一不足する `make` を `brew install make` で調達(gmake として入るため `gmake bootstrap` にフォールバック)。apt も brew も無い環境は明示エラー |
| `Makefile` | apt 前提パッケージ導入を `command -v apt-get` ガードで条件化 |
| `support-japanese.sh` | Fedora Atomic では `localectl set-locale LANG=ja_JP.UTF-8` のみ実行(ロケール・フォント・mozc は同梱済みのため) |
| `change-default-shell.sh` | chsh 不在時は `usermod --shell` にフォールバック。**ostree 環境では brew シェルへの login shell 変更を拒否**(公式非推奨・起動不能報告 ublue-os/bazzite#4159)し、Ptyxis での設定方法を案内 |
| `install-flatpak.sh` | flatpak 導入済みの非 apt ディストリではインストールをスキップ |
| `install-tailscale.sh` | ostree 環境で公式インストーラを実行しない安全ガード(Bazzite は同梱のため通常は既存の `command -v` ガードで先にスキップされる) |
| README | Bazzite 利用の節を追加 |

## Ubuntu への影響

**なし**(すべての apt 処理は `command -v apt-get` の真側にそのまま残っています)。このPRの Linux Bootstrap Test(Ubuntu フル bootstrap)がリグレッションを検証します。

## テスト

- BATS 全スイートパス。新規テスト2件を追加:
  - ostree マーカーあり + brew シェル選択 → スキップして exit 0(案内表示)
  - ostree マーカーなし → 変更コマンドまで到達(**sudo をスタブ**して実シェル変更なしで検証)
- shellcheck(warning)全クリーン、`make -n` パース OK

## 制約

- Bazzite 実機/VM での end-to-end 検証は未実施です(ostree/初回ブートの brew 展開が CI コンテナで忠実に再現できないため)。実機で試す場合は README の Bazzite 節の手順どおりワンライナーを実行してください
- login shell は変更されません(公式推奨に従い、Ptyxis のプロファイルで zsh を起動する方式)

🤖 Generated with [Claude Code](https://claude.com/claude-code)