### PR TITLE
Migrate nvim-treesitter to main branch for Neovim 0.12

### DIFF
--- a/Brewfiles/minimum-Brewfile
+++ b/Brewfiles/minimum-Brewfile
@@ -87,6 +87,7 @@ brew "tree"  # ディレクトリツリー表示
 
 # Neovim関連
 brew "ripgrep"  # 高速grepツール(Neovim用)
+brew "tree-sitter-cli"  # tree-sitterパーサービルド用CLI(nvim-treesitter main用)
 
 # Apps (macOSのみ。Linux の GUI アプリは make linux_gui_setup / フォントは make font)
 if OS.mac?

--- a/configs/nvim/lua/shoichi/plugins/treesitter.lua
+++ b/configs/nvim/lua/shoichi/plugins/treesitter.lua
@@ -1,54 +1,64 @@
 return {
   "nvim-treesitter/nvim-treesitter",
-  branch = "master",
-  event = { "BufReadPre", "BufNewFile" },
+  -- master ブランチは frozen かつ Neovim 0.12 非サポート (README)。
+  -- 0.12 でクエリマッチ API が変わり master のインジェクション用ディレクティブが
+  -- クラッシュするため、0.12+ 専用の main ブランチへ移行する。
+  branch = "main",
+  -- main ブランチは lazy-loading 非対応 (README) のため常時ロードする。
+  lazy = false,
   build = ":TSUpdate",
   dependencies = {
     "windwp/nvim-ts-autotag",
   },
   config = function()
-    -- import nvim-treesitter plugin
-    local treesitter = require("nvim-treesitter.configs")
+    local treesitter = require("nvim-treesitter")
 
-    -- configure treesitter
-    treesitter.setup({ -- enable syntax highlighting
-      highlight = {
-        enable = true,
-      },
-      -- enable indentation
-      indent = { enable = true },
-      -- ensure these language parsers are installed
-      ensure_installed = {
-        "json",
-        "javascript",
-        "typescript",
-        "tsx",
-        "yaml",
-        "html",
-        "css",
-        "prisma",
-        "markdown",
-        "markdown_inline",
-        "svelte",
-        "graphql",
-        "bash",
-        "lua",
-        "vim",
-        "dockerfile",
-        "gitignore",
-        "query",
-        "vimdoc",
-        "c",
-      },
-      incremental_selection = {
-        enable = true,
-        keymaps = {
-          init_selection = "<C-space>",
-          node_incremental = "<C-space>",
-          scope_incremental = false,
-          node_decremental = "<bs>",
-        },
-      },
+    treesitter.setup()
+
+    -- インストールするパーサー
+    local ensure_installed = {
+      "json",
+      "javascript",
+      "typescript",
+      "tsx",
+      "yaml",
+      "html",
+      "css",
+      "prisma",
+      "markdown",
+      "markdown_inline",
+      "svelte",
+      "graphql",
+      "bash",
+      "lua",
+      "vim",
+      "dockerfile",
+      "gitignore",
+      "query",
+      "vimdoc",
+      "c",
+    }
+
+    -- 未インストールのパーサーのみ install する (install は非同期)。
+    local ok_installed, installed = pcall(treesitter.get_installed)
+    local to_install = ensure_installed
+    if ok_installed then
+      to_install = vim.tbl_filter(function(lang)
+        return not vim.tbl_contains(installed, lang)
+      end, ensure_installed)
+    end
+    if #to_install > 0 then
+      treesitter.install(to_install)
+    end
+
+    -- main ブランチはハイライト/インデントを自動で有効化しないため、
+    -- FileType ごとにパーサーが利用可能なら treesitter を起動する。
+    vim.api.nvim_create_autocmd("FileType", {
+      callback = function(args)
+        if pcall(vim.treesitter.start, args.buf) then
+          vim.bo[args.buf].indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+        end
+      end,
     })
 
     -- nvim-ts-autotag は treesitter モジュール統合 (autotag = { enable = true })


### PR DESCRIPTION
## 問題

`nvim` 起動時（markdown を開く際の `BufWinEnter`）に以下のエラーが発生していた:

```
Error in BufWinEnter Autocommands for "*":
Lua callback: .../vim/treesitter.lua:196: attempt to call method 'range' (a nil value)
  ...nvim-treesitter/lua/nvim-treesitter/query_predicates.lua:141: in function 'handler'
  ...markview.nvim/lua/markview/parser.lua:160: in function 'parse'
```

## 原因

nvim-treesitter の **`master` ブランチは frozen かつ Neovim 0.12 を非サポート**（[README](https://github.com/nvim-treesitter/nvim-treesitter/blob/master/README.md) に「Neovim 0.10 or 0.11 … 0.12 is **not supported**」と明記）。

Neovim 0.12 でクエリマッチ API が変わり、ディレクティブハンドラに渡る `captures[id]` が**単一ノードから `TSNode[]`（配列）に変更**された。master ブランチの markdown インジェクション用ディレクティブ `set-lang-from-info-string!`（`query_predicates.lua:141`）は単一ノード前提で `node:range()` を呼ぶため nil クラッシュしていた。markdown をレンダリングする markview.nvim 経由で顕在化していた。

## 修正

upstream 推奨どおり **`main` ブランチへ移行**（main は 0.12+ 専用）:

- `configs/nvim/lua/shoichi/plugins/treesitter.lua`
  - `branch = "main"` / `lazy = false`（main は lazy-loading 非対応）
  - API 変更（`nvim-treesitter.configs` 廃止）に伴い、`install()` でパーサーを導入し、`FileType` autocmd で `vim.treesitter.start()` + `indentexpr` を有効化
  - 起動毎の再ビルドを避けるため未インストールのパーサーのみ `install()`
- `Brewfiles/minimum-Brewfile`
  - `tree-sitter-cli` を追加（main はパーサービルドに `tree-sitter` CLI が必須。従来 neovim 依存で入る `tree-sitter` はライブラリのみで CLI を含まない）

## 破壊的変更

main ブランチには `incremental_selection` モジュールが存在しないため、`<C-space>` / `<bs>` によるノード選択は廃止（未ドキュメント機能）。

## 検証（実機 / Neovim 0.12.2）

- `:Lazy sync` で main ブランチへ切替、`tree-sitter-cli` 導入後に全21パーサーのビルド成功
- markdown を開いて元のクラッシュが**再現しないこと**を確認（`attempt to call method 'range'` なし）
- treesitter ハイライト有効（`highlighter.active` = true）、`indentexpr` 設定確認
- `Markview Toggle` の往復動作、パーサー未対応 filetype での pcall ガード動作を確認、エラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)