### PR TITLE
Fix 1password-cli install by using cask instead of brew

### DIFF
--- a/Brewfiles/extra-Brewfile
+++ b/Brewfiles/extra-Brewfile
@@ -18,7 +18,7 @@ brew "ffmpeg"  # 動画/音声処理
 
 # パスワード管理 / アプリケーション (macOSのみ)
 if OS.mac?
-  brew "1password-cli"  # 1Password CLI (op コマンド)
+  cask "1password-cli"  # 1Password CLI (op コマンド)
   cask "ghostty"  # モダンなGPU加速ターミナル
   cask "google-chrome"  # Webブラウザ
   cask "1password"  # パスワードマネージャ


### PR DESCRIPTION
## 概要
新しい Mac でクリーンインストール時に `make bootstrap` (extra) が `1password-cli` のインストールで失敗する問題を修正。

## 原因
1Password CLI は Homebrew では **cask** としてのみ提供されており、同名の formula は存在しない。`Brewfiles/extra-Brewfile` が `brew "1password-cli"` を指定していたため、クリーン環境で `No available formula with the name "1password-cli"` エラーになっていた。

## 変更
- `Brewfiles/extra-Brewfile`: `brew "1password-cli"` → `cask "1password-cli"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XwAsokGbVkN1a3bKrVYFCW